### PR TITLE
PROPOSED CHANGE TO STOP CWD FROM BEING CAPTURED

### DIFF
--- a/src/sdk/nodepod.ts
+++ b/src/sdk/nodepod.ts
@@ -347,7 +347,7 @@ export class Nodepod {
       shellHandle = this._processManager.spawn({
         command: "shell",
         args: [],
-        cwd: this._cwd,
+        cwd: terminal.getCwd(),
         env: this._env,
       });
       shellReady = new Promise<void>((resolve) => {
@@ -431,7 +431,7 @@ export class Nodepod {
           type: "exec",
           filePath: "",
           args: [],
-          cwd: this._cwd,
+          cwd: terminal.getCwd(),
           isShell: true,
           shellCommand: cmd,
           persistent: true,


### PR DESCRIPTION
when I call createTerminal, then call setCwd, then call ls , it doesn't honor my setCwd call, I think this is because this._cwd is captured and not driven from current terminal.getCwd()