### PR TITLE
feat: add sh -c to interpreter

### DIFF
--- a/src/__tests__/shell-interpreter.test.ts
+++ b/src/__tests__/shell-interpreter.test.ts
@@ -154,4 +154,26 @@ describe("NodepodShell", () => {
       expect(result.stdout).not.toContain("c.js");
     });
   });
+
+  describe("sh -c support", () => {
+    it("sh -c executes simple command", async () => {
+      const { shell } = createShell();
+      const result = await shell.exec("sh -c 'echo hello'");
+      expect(result.stdout).toBe("hello\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("sh -c handles pipes correctly", async () => {
+      const { shell } = createShell();
+      const result = await shell.exec("sh -c 'echo hello world | wc -w'");
+      expect(result.stdout.trim()).toBe("2");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("sh -c handles chained commands", async () => {
+      const { shell } = createShell();
+      const result = await shell.exec("sh -c 'echo a && echo b'");
+      expect(result.stdout).toBe("a\nb\n");
+    });
+  });
 });

--- a/src/shell/shell-interpreter.ts
+++ b/src/shell/shell-interpreter.ts
@@ -214,6 +214,11 @@ export class NodepodShell {
       expandedArgs = [...aliasArgs, ...expandedArgs.slice(1)];
     }
 
+    // extract "sh -c" commands and execute them
+    if (expandedArgs[0] === "sh" && expandedArgs[1] === "-c" && expandedArgs[2]) {
+      return this.exec(expandedArgs[2], { cwd: this.cwd, env: this.env });
+    }
+
     const name = expandedArgs[0];
     const args = expandedArgs.slice(1);
 


### PR DESCRIPTION
This adds the "sh -c" command to the interpreter and also adds tests for it. Closes #24.