### PR TITLE
fix: mkdir and siblings not notifying onGlobalChange (#23)

### DIFF
--- a/src/__tests__/memory-volume.test.ts
+++ b/src/__tests__/memory-volume.test.ts
@@ -440,4 +440,166 @@ describe("MemoryVolume", () => {
       expect(stats.isFile()).toBe(true);
     });
   });
+
+  // regression tests for issue #23. mkdir and a few other mutators were
+  // changing the tree without telling onGlobalChange subscribers, so anything
+  // tracking fs changes (HMR, vfs-bridge, user code) silently missed them
+  describe("onGlobalChange dispatch", () => {
+    it("fires 'addDir' when mkdirSync creates a directory", () => {
+      const vol = new MemoryVolume();
+      const events: Array<{ path: string; event: string }> = [];
+      vol.onGlobalChange((path, event) => events.push({ path, event }));
+
+      vol.mkdirSync("/dir");
+
+      expect(events).toEqual([{ path: "/dir", event: "addDir" }]);
+    });
+
+    it("fires 'addDir' for every newly created segment with recursive:true", () => {
+      const vol = new MemoryVolume();
+      const events: Array<{ path: string; event: string }> = [];
+      vol.onGlobalChange((path, event) => events.push({ path, event }));
+
+      vol.mkdirSync("/a/b/c", { recursive: true });
+
+      expect(events).toEqual([
+        { path: "/a", event: "addDir" },
+        { path: "/a/b", event: "addDir" },
+        { path: "/a/b/c", event: "addDir" },
+      ]);
+    });
+
+    it("stays silent when mkdirSync(recursive:true) hits an existing tree", () => {
+      const vol = new MemoryVolume();
+      vol.mkdirSync("/a/b/c", { recursive: true });
+
+      const events: Array<{ path: string; event: string }> = [];
+      vol.onGlobalChange((path, event) => events.push({ path, event }));
+
+      vol.mkdirSync("/a/b/c", { recursive: true });
+      expect(events).toEqual([]);
+    });
+
+    it("fires only for missing segments when mkdirSync(recursive:true) partially exists", () => {
+      const vol = new MemoryVolume();
+      vol.mkdirSync("/a", { recursive: true });
+
+      const events: Array<{ path: string; event: string }> = [];
+      vol.onGlobalChange((path, event) => events.push({ path, event }));
+
+      vol.mkdirSync("/a/b/c", { recursive: true });
+      expect(events).toEqual([
+        { path: "/a/b", event: "addDir" },
+        { path: "/a/b/c", event: "addDir" },
+      ]);
+    });
+
+    it("fires 'add' / 'change' for writeFileSync", () => {
+      const vol = new MemoryVolume();
+      const events: Array<{ path: string; event: string }> = [];
+      vol.onGlobalChange((path, event) => events.push({ path, event }));
+
+      vol.writeFileSync("/f.txt", "hello");
+      vol.writeFileSync("/f.txt", "world");
+
+      expect(events).toEqual([
+        { path: "/f.txt", event: "add" },
+        { path: "/f.txt", event: "change" },
+      ]);
+    });
+
+    it("fires 'unlink' for unlinkSync", () => {
+      const vol = new MemoryVolume();
+      vol.writeFileSync("/f.txt", "data");
+
+      const events: Array<{ path: string; event: string }> = [];
+      vol.onGlobalChange((path, event) => events.push({ path, event }));
+
+      vol.unlinkSync("/f.txt");
+      expect(events).toEqual([{ path: "/f.txt", event: "unlink" }]);
+    });
+
+    it("fires 'unlink' for rmdirSync", () => {
+      const vol = new MemoryVolume();
+      vol.mkdirSync("/dir");
+
+      const events: Array<{ path: string; event: string }> = [];
+      vol.onGlobalChange((path, event) => events.push({ path, event }));
+
+      vol.rmdirSync("/dir");
+      expect(events).toEqual([{ path: "/dir", event: "unlink" }]);
+    });
+
+    it("fires 'change' for truncateSync", () => {
+      const vol = new MemoryVolume();
+      vol.writeFileSync("/f.txt", "hello world");
+
+      const events: Array<{ path: string; event: string }> = [];
+      vol.onGlobalChange((path, event) => events.push({ path, event }));
+
+      vol.truncateSync("/f.txt", 5);
+      expect(events).toEqual([{ path: "/f.txt", event: "change" }]);
+    });
+
+    it("fires 'add' for symlinkSync", () => {
+      const vol = new MemoryVolume();
+      vol.writeFileSync("/target.txt", "target");
+
+      const events: Array<{ path: string; event: string }> = [];
+      vol.onGlobalChange((path, event) => events.push({ path, event }));
+
+      vol.symlinkSync("/target.txt", "/link.txt");
+      expect(events).toEqual([{ path: "/link.txt", event: "add" }]);
+    });
+
+    it("fires 'add' for linkSync", () => {
+      const vol = new MemoryVolume();
+      vol.writeFileSync("/original.txt", "data");
+
+      const events: Array<{ path: string; event: string }> = [];
+      vol.onGlobalChange((path, event) => events.push({ path, event }));
+
+      vol.linkSync("/original.txt", "/hardlink.txt");
+      expect(events).toEqual([{ path: "/hardlink.txt", event: "add" }]);
+    });
+
+    it("fires 'unlink' + 'add' for renameSync", () => {
+      const vol = new MemoryVolume();
+      vol.writeFileSync("/old.txt", "data");
+
+      const events: Array<{ path: string; event: string }> = [];
+      vol.onGlobalChange((path, event) => events.push({ path, event }));
+
+      vol.renameSync("/old.txt", "/new.txt");
+      expect(events).toContainEqual({ path: "/old.txt", event: "unlink" });
+      expect(events).toContainEqual({ path: "/new.txt", event: "add" });
+    });
+
+    it("onGlobalChange returns an unsubscribe fn", () => {
+      const vol = new MemoryVolume();
+      const events: Array<{ path: string; event: string }> = [];
+      const unsubscribe = vol.onGlobalChange((path, event) =>
+        events.push({ path, event }),
+      );
+
+      vol.mkdirSync("/a");
+      unsubscribe();
+      vol.mkdirSync("/b");
+
+      expect(events).toEqual([{ path: "/a", event: "addDir" }]);
+    });
+
+    it("also fires a parallel fs.watch event for mkdir", () => {
+      const vol = new MemoryVolume();
+      const watchEvents: Array<{ event: string; filename: string | null }> = [];
+      vol.watch("/", { recursive: true }, (event, filename) => {
+        watchEvents.push({ event, filename });
+      });
+
+      vol.mkdirSync("/dir");
+
+      // triggerWatchers uses Node's fs.watch vocabulary ('rename' / 'change')
+      expect(watchEvents).toEqual([{ event: "rename", filename: "dir" }]);
+    });
+  });
 });

--- a/src/memory-volume.ts
+++ b/src/memory-volume.ts
@@ -502,6 +502,36 @@ export class MemoryVolume {
     return current;
   }
 
+  // same as ensureDir but returns the list of segments it actually had to create,
+  // so mkdirSync(recursive: true) can fire one addDir per new dir and stay quiet
+  // about ones that already existed
+  private ensureDirTracked(p: string): { node: VolumeNode; created: string[] } {
+    const created: string[] = [];
+    if (p === '/') return { node: this.tree, created };
+    let current = this.tree;
+    let start = 1;
+    const len = p.length;
+    let currentPath = '';
+    while (start < len) {
+      let end = p.indexOf('/', start);
+      if (end === -1) end = len;
+      const seg = p.substring(start, end);
+      start = end + 1;
+      currentPath = currentPath + '/' + seg;
+      if (!current.children) current.children = new Map();
+      let child = current.children.get(seg);
+      if (!child) {
+        child = { kind: 'directory', children: new Map(), modified: Date.now() };
+        current.children.set(seg, child);
+        created.push(currentPath);
+      } else if (child.kind !== 'directory') {
+        throw new Error(`ENOTDIR: not a directory, '${p}'`);
+      }
+      current = child;
+    }
+    return { node: current, created };
+  }
+
   // ---- Internal write ----
 
   // expects pre-normalized path
@@ -660,7 +690,12 @@ export class MemoryVolume {
     const norm = this.normalize(p);
 
     if (options?.recursive) {
-      this.ensureDir(norm);
+      const { created } = this.ensureDirTracked(norm);
+      for (const path of created) {
+        if (this._handler) this._handler.invalidateStat(path);
+        this.triggerWatchers(path, 'rename');
+        this.notifyGlobalListeners(path, 'addDir');
+      }
       return;
     }
 
@@ -678,6 +713,10 @@ export class MemoryVolume {
       children: new Map(),
       modified: Date.now(),
     });
+
+    if (this._handler) this._handler.invalidateStat(norm);
+    this.triggerWatchers(norm, 'rename');
+    this.notifyGlobalListeners(norm, 'addDir');
   }
 
   readdirSync(p: string): string[] {
@@ -837,6 +876,10 @@ export class MemoryVolume {
       target: this.normalize(target),
       modified: Date.now(),
     });
+
+    if (this._handler) this._handler.invalidateStat(normLink);
+    this.triggerWatchers(normLink, 'rename');
+    this.notifyGlobalListeners(normLink, 'add');
   }
 
   readlinkSync(p: string): string {
@@ -869,6 +912,10 @@ export class MemoryVolume {
       content: existing.content,
       modified: existing.modified,
     });
+
+    if (this._handler) this._handler.invalidateStat(normNew);
+    this.triggerWatchers(normNew, 'rename');
+    this.notifyGlobalListeners(normNew, 'add');
   }
 
   chmodSync(_p: string, _mode: number): void {
@@ -910,6 +957,10 @@ export class MemoryVolume {
       node.content = bigger;
     }
     node.modified = Date.now();
+
+    if (this._handler) this._handler.invalidateStat(norm);
+    this.triggerWatchers(norm, 'change');
+    this.notifyGlobalListeners(norm, 'change');
   }
 
   // ---- Async wrappers ----

--- a/src/polyfills/events.ts
+++ b/src/polyfills/events.ts
@@ -41,6 +41,8 @@ function _bridgeVfsToWatcher(watcher: EventEmitter): void {
           watcher.emit('change', path);
         } else if (event === 'add') {
           watcher.emit('add', path);
+        } else if (event === 'addDir') {
+          watcher.emit('addDir', path);
         } else if (event === 'unlink') {
           watcher.emit('unlink', path);
         }


### PR DESCRIPTION
Several VFS mutators were changing the tree without firing the change notifications that writeFileSync/unlinkSync/rmdirSync all use, so volume.onGlobalChange subscribers silently missed them.

- mkdirSync now emits 'addDir'. With recursive:true it emits one event per newly-created segment and stays quiet when the path already exists. Added an ensureDirTracked helper that reports which segments were new.
- truncateSync emits 'change'
- symlinkSync and linkSync emit 'add'
- chokidar bridge in polyfills/events.ts forwards the new 'addDir' event through to FSWatcher so HMR sees it too

12 new tests covering onGlobalChange dispatch for every mutator, plus the partial-exists recursive case and the unsubscribe return value.

All 404 tests pass.