### PR TITLE
feat: propagate terminal size to process.stdout (#26)

### DIFF
--- a/examples/serve.js
+++ b/examples/serve.js
@@ -50,4 +50,5 @@ createServer((req, res) => {
   console.log(`  Vite build test:      http://localhost:${port}/examples/vite-build-test/`);
   console.log(`  Native WASI test:     http://localhost:${port}/examples/native-wasi-test/`);
   console.log(`  SW setup DX:          http://localhost:${port}/examples/sw-setup/`);
+  console.log(`  Terminal resize:      http://localhost:${port}/examples/terminal-resize/`);
 });

--- a/examples/terminal-resize/index.html
+++ b/examples/terminal-resize/index.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>nodepod terminal resize</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: system-ui, sans-serif; background: #0d1117; color: #c9d1d9; height: 100vh; display: flex; flex-direction: column; }
+    header { padding: 12px 16px; background: #161b22; border-bottom: 1px solid #30363d; display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+    header h1 { font-size: 14px; font-weight: 600; }
+    header .muted { font-size: 12px; color: #8b949e; }
+    header .size { font-size: 12px; color: #58a6ff; font-family: monospace; margin-left: auto; background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 3px 8px; }
+    header .size strong { color: #c9d1d9; }
+    .container { flex: 1; display: flex; min-height: 0; }
+    #terminal-panel { flex: 1; display: flex; flex-direction: column; }
+    #terminal-box { flex: 1; padding: 6px; }
+    #resize-panel { width: 340px; border-left: 1px solid #30363d; background: #0d1117; padding: 14px 16px; overflow-y: auto; font-size: 12px; line-height: 1.5; }
+    #resize-panel h2 { font-size: 12px; font-weight: 600; margin-bottom: 8px; color: #c9d1d9; }
+    #resize-panel p { color: #8b949e; margin-bottom: 10px; }
+    #resize-panel code { background: #161b22; border: 1px solid #30363d; border-radius: 3px; padding: 1px 5px; font-family: monospace; color: #79c0ff; font-size: 11px; }
+    #resize-panel .log { background: #161b22; border: 1px solid #30363d; border-radius: 4px; padding: 8px; font-family: monospace; font-size: 11px; color: #8b949e; max-height: 220px; overflow-y: auto; white-space: pre-wrap; }
+    #resize-panel .log .row { color: #c9d1d9; }
+    #resize-panel .log .ts { color: #484f58; }
+    #resize-panel details { margin-top: 12px; border: 1px solid #30363d; border-radius: 4px; padding: 8px 10px; background: #161b22; }
+    #resize-panel summary { cursor: pointer; font-weight: 600; color: #c9d1d9; font-size: 11px; }
+    #resize-panel pre { margin-top: 8px; font-family: monospace; font-size: 10.5px; color: #8b949e; white-space: pre-wrap; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>nodepod</h1>
+    <span class="muted">terminal resize demo</span>
+    <span class="size">terminal: <strong id="size-cols">?</strong>x<strong id="size-rows">?</strong></span>
+  </header>
+  <div class="container">
+    <div id="terminal-panel">
+      <div id="terminal-box"></div>
+    </div>
+    <aside id="resize-panel">
+      <h2>what this shows</h2>
+      <p>
+        xterm reflows on window resize via FitAddon, the new size is forwarded
+        to the worker, and the running script's <code>process.stdout.columns</code>
+        and <code>process.stdout.rows</code> update with a <code>'resize'</code>
+        event so TUI libraries can react.
+      </p>
+      <p>
+        run <code>node tui.js</code> then drag the window edge to resize.
+      </p>
+      <h2 style="margin-top:14px">resize events</h2>
+      <div class="log" id="log"></div>
+      <details>
+        <summary>tui.js source</summary>
+        <pre id="src"></pre>
+      </details>
+    </aside>
+  </div>
+
+  <script type="module">
+    import { Nodepod } from "/dist/index.mjs";
+    import { Terminal } from "https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/+esm";
+    import { FitAddon } from "https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/+esm";
+
+    // a tiny TUI that redraws when process.stdout fires 'resize'. it also
+    // prints the size once at startup so you can see it react live.
+    const tuiSource = `
+const draw = () => {
+  const cols = process.stdout.columns;
+  const rows = process.stdout.rows;
+  const title = " nodepod terminal resize demo ";
+  const pad = Math.max(0, cols - title.length - 2);
+  const line = "+" + "-".repeat(Math.max(0, cols - 2)) + "+";
+  // clear and move to 0,0
+  process.stdout.write("\\x1b[2J\\x1b[H");
+  process.stdout.write(line + "\\n");
+  process.stdout.write("|" + title + " ".repeat(pad) + "|\\n");
+  process.stdout.write(line + "\\n");
+  process.stdout.write("cols: " + cols + "   rows: " + rows + "\\n");
+  process.stdout.write("isTTY: " + process.stdout.isTTY + "\\n");
+  process.stdout.write("drag the window edge to resize, ctrl+c to quit\\n");
+};
+
+draw();
+process.stdout.on("resize", draw);
+
+// keep the process alive until ctrl+c
+process.stdin.setRawMode?.(true);
+process.stdin.resume?.();
+process.stdin.on("data", (chunk) => {
+  const s = chunk.toString();
+  if (s === "\\x03") {
+    process.stdout.write("\\nbye\\n");
+    process.exit(0);
+  }
+});
+`;
+
+    document.getElementById("src").textContent = tuiSource.trim();
+
+    const sizeCols = document.getElementById("size-cols");
+    const sizeRows = document.getElementById("size-rows");
+    const logEl = document.getElementById("log");
+    const appendLog = (msg) => {
+      const ts = new Date().toLocaleTimeString();
+      logEl.insertAdjacentHTML("afterbegin",
+        `<div class="row"><span class="ts">${ts}</span>  ${msg}</div>`);
+    };
+
+    const nodepod = await Nodepod.boot({
+      swUrl: "/__sw__.js",
+      workdir: "/home",
+      files: {
+        "/home/tui.js": tuiSource,
+      },
+    });
+
+    const terminal = nodepod.createTerminal({
+      Terminal,
+      FitAddon,
+      fontSize: 13,
+      fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
+    });
+
+    terminal.attach(document.getElementById("terminal-box"));
+
+    // xterm fires onResize after every reflow. we mirror that into the UI
+    // so you can see nodepod's bridge and xterm agree on the size.
+    const xterm = terminal.xterm;
+    const updateBadge = () => {
+      if (!xterm) return;
+      sizeCols.textContent = xterm.cols;
+      sizeRows.textContent = xterm.rows;
+    };
+    updateBadge();
+    xterm?.onResize?.((dim) => {
+      updateBadge();
+      appendLog(`xterm onResize -> ${dim.cols}x${dim.rows}`);
+    });
+
+    // quality of life: drop a ready message in the terminal so you don't
+    // have to read the side panel to know what to type
+    setTimeout(() => {
+      terminal.writeln("");
+      terminal.writeln("\x1b[36mtry: \x1b[0m\x1b[32mnode tui.js\x1b[0m");
+      terminal.writeln("\x1b[90mthen resize the window and watch the TUI redraw\x1b[0m");
+      terminal.showPrompt();
+    }, 250);
+  </script>
+</body>
+</html>

--- a/src/__tests__/process.test.ts
+++ b/src/__tests__/process.test.ts
@@ -176,5 +176,24 @@ describe("process polyfill", () => {
       proc.stdout.columns = Number.NaN;
       expect(proc.stdout.columns).toBe(100);
     });
+
+    it("also fires 'resize' on stderr (Node-accurate, both WriteStreams emit)", () => {
+      const proc = buildProcessEnv();
+      const fn = vi.fn();
+      proc.stderr.on("resize", fn);
+      const changed = setStreamDimensions(proc.stderr as any, 140, 42);
+      expect(changed).toBe(true);
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT fire 'resize' on stdin (matches tty.ReadStream)", () => {
+      const proc = buildProcessEnv();
+      const fn = vi.fn();
+      proc.stdin.on("resize", fn);
+      // stdin has no _setSize. setStreamDimensions is a no-op.
+      const changed = setStreamDimensions(proc.stdin as any, 140, 42);
+      expect(changed).toBe(false);
+      expect(fn).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/__tests__/process.test.ts
+++ b/src/__tests__/process.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { buildProcessEnv } from "../polyfills/process";
+import { buildProcessEnv, setStreamDimensions } from "../polyfills/process";
 
 describe("process polyfill", () => {
   describe("basic properties", () => {
@@ -124,6 +124,57 @@ describe("process polyfill", () => {
       proc.on("SIGTERM", fn);
       proc.kill(proc.pid, "SIGTERM");
       expect(fn).toHaveBeenCalled();
+    });
+  });
+
+  describe("stdout resize", () => {
+    it("emits 'resize' when columns or rows change via assignment", () => {
+      const proc = buildProcessEnv();
+      const fn = vi.fn();
+      proc.stdout.on("resize", fn);
+      proc.stdout.columns = 120;
+      expect(proc.stdout.columns).toBe(120);
+      expect(fn).toHaveBeenCalledTimes(1);
+      proc.stdout.rows = 40;
+      expect(proc.stdout.rows).toBe(40);
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not emit 'resize' when assigning the same value", () => {
+      const proc = buildProcessEnv();
+      const fn = vi.fn();
+      proc.stdout.on("resize", fn);
+      const c = proc.stdout.columns;
+      proc.stdout.columns = c;
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    it("setStreamDimensions fires a single 'resize' event for both dims", () => {
+      const proc = buildProcessEnv();
+      const fn = vi.fn();
+      proc.stdout.on("resize", fn);
+      const changed = setStreamDimensions(proc.stdout as any, 150, 50);
+      expect(changed).toBe(true);
+      expect(proc.stdout.columns).toBe(150);
+      expect(proc.stdout.rows).toBe(50);
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("setStreamDimensions is a no-op when nothing changed", () => {
+      const proc = buildProcessEnv();
+      setStreamDimensions(proc.stdout as any, 150, 50);
+      const fn = vi.fn();
+      proc.stdout.on("resize", fn);
+      const changed = setStreamDimensions(proc.stdout as any, 150, 50);
+      expect(changed).toBe(false);
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    it("ignores non-finite writes to columns/rows", () => {
+      const proc = buildProcessEnv();
+      proc.stdout.columns = 100;
+      proc.stdout.columns = Number.NaN;
+      expect(proc.stdout.columns).toBe(100);
     });
   });
 });

--- a/src/polyfills/child_process.ts
+++ b/src/polyfills/child_process.ts
@@ -44,16 +44,15 @@ let _rawModeChangeCb: ((isRaw: boolean) => void) | null = null;
 const _activeProcs = new Set<{
   stdout: { _setSize?: (c: number, r: number) => boolean };
   stderr: { _setSize?: (c: number, r: number) => boolean };
-  stdin: { _setSize?: (c: number, r: number) => boolean };
 }>();
 
 // called by the worker when it gets a "resize" from the main thread.
-// updates every live proc's stdout/stderr/stdin and emits 'resize' on each.
+// matches Node: only stdout and stderr fire 'resize', stdin is a ReadStream
+// and doesn't have the event at all.
 export function notifyTerminalResize(cols: number, rows: number): void {
   for (const p of _activeProcs) {
     p.stdout?._setSize?.(cols, rows);
     p.stderr?._setSize?.(cols, rows);
-    p.stdin?._setSize?.(cols, rows);
   }
 }
 
@@ -1166,8 +1165,8 @@ export async function executeNodeBinary(
     proc.stdout.rows = rows;
     proc.stderr.columns = cols;
     proc.stderr.rows = rows;
-    proc.stdin.columns = cols;
-    proc.stdin.rows = rows;
+    // stdin intentionally skipped -- real Node's tty.ReadStream has no
+    // columns/rows/resize, TUIs watch process.stdout for dimensions
     proc.stdin.setRawMode = (flag: boolean) => {
       proc.stdin.isRaw = flag;
       // notify terminal so it switches echo mode

--- a/src/polyfills/child_process.ts
+++ b/src/polyfills/child_process.ts
@@ -39,6 +39,24 @@ let _termRows: (() => number) | null = null;
 
 let _rawModeChangeCb: ((isRaw: boolean) => void) | null = null;
 
+// every executeNodeBinary adds its proc here so terminal resizes can be
+// pushed to the currently-running script. cleared on exit.
+const _activeProcs = new Set<{
+  stdout: { _setSize?: (c: number, r: number) => boolean };
+  stderr: { _setSize?: (c: number, r: number) => boolean };
+  stdin: { _setSize?: (c: number, r: number) => boolean };
+}>();
+
+// called by the worker when it gets a "resize" from the main thread.
+// updates every live proc's stdout/stderr/stdin and emits 'resize' on each.
+export function notifyTerminalResize(cols: number, rows: number): void {
+  for (const p of _activeProcs) {
+    p.stdout?._setSize?.(cols, rows);
+    p.stderr?._setSize?.(cols, rows);
+    p.stdin?._setSize?.(cols, rows);
+  }
+}
+
 // context-aware state accessors: check ProcessContext first, fall back to module globals
 
 function getStdoutSink(): ((text: string) => void) | null {
@@ -1148,6 +1166,8 @@ export async function executeNodeBinary(
     proc.stdout.rows = rows;
     proc.stderr.columns = cols;
     proc.stderr.rows = rows;
+    proc.stdin.columns = cols;
+    proc.stdin.rows = rows;
     proc.stdin.setRawMode = (flag: boolean) => {
       proc.stdin.isRaw = flag;
       // notify terminal so it switches echo mode
@@ -1158,6 +1178,10 @@ export async function executeNodeBinary(
     // also update context's liveStdin
     const ctx = getActiveContext();
     if (ctx) ctx.liveStdin = proc.stdin;
+
+    // register with the resize broadcaster so live SIGWINCH-style updates
+    // reach the running script's process.stdout / stderr / stdin
+    _activeProcs.add(proc as any);
   }
 
   // for forked children: ref() to simulate the IPC channel handle.
@@ -1394,6 +1418,7 @@ export async function executeNodeBinary(
     _liveStdin = prevLiveStdin;
     const ctxRestore = getActiveContext();
     if (ctxRestore) ctxRestore.liveStdin = prevLiveStdin;
+    _activeProcs.delete(proc as any);
     // full reset
     closeAllServers();
     resetRefCount();
@@ -2309,4 +2334,5 @@ export default {
   setIPCReceiveHandler,
   handleIPCFromParent,
   executeNodeBinary,
+  notifyTerminalResize,
 };

--- a/src/polyfills/process.ts
+++ b/src/polyfills/process.ts
@@ -391,49 +391,52 @@ function fabricateStream(
     };
   }
 
-  // swap the plain columns/rows properties for accessors that emit 'resize'
-  // if someone assigns the same value we don't emit, otherwise watchers get
-  // spammed on every fit() call even when the size didn't actually change
-  let _silent = false;
-  Object.defineProperty(stream, "columns", {
-    get() { return _cols; },
-    set(v: number) {
-      const n = typeof v === "number" ? v : Number(v);
-      if (!Number.isFinite(n) || n === _cols) return;
-      _cols = n;
-      if (!_silent) bus.emit("resize");
-    },
-    enumerable: true,
-    configurable: true,
-  });
-  Object.defineProperty(stream, "rows", {
-    get() { return _rows; },
-    set(v: number) {
-      const n = typeof v === "number" ? v : Number(v);
-      if (!Number.isFinite(n) || n === _rows) return;
-      _rows = n;
-      if (!_silent) bus.emit("resize");
-    },
-    enumerable: true,
-    configurable: true,
-  });
+  // only the output streams (stdout/stderr) fire 'resize' in real Node,
+  // since stdin is a tty.ReadStream which has no columns/rows/resize.
+  // we still keep columns/rows on the stdin object for back-compat with
+  // anything that was already reading them, but we don't emit anything.
+  if (isOutput) {
+    let _silent = false;
+    Object.defineProperty(stream, "columns", {
+      get() { return _cols; },
+      set(v: number) {
+        const n = typeof v === "number" ? v : Number(v);
+        if (!Number.isFinite(n) || n === _cols) return;
+        _cols = n;
+        if (!_silent) bus.emit("resize");
+      },
+      enumerable: true,
+      configurable: true,
+    });
+    Object.defineProperty(stream, "rows", {
+      get() { return _rows; },
+      set(v: number) {
+        const n = typeof v === "number" ? v : Number(v);
+        if (!Number.isFinite(n) || n === _rows) return;
+        _rows = n;
+        if (!_silent) bus.emit("resize");
+      },
+      enumerable: true,
+      configurable: true,
+    });
 
-  // update both at once, emit 'resize' once. individual setter assignments
-  // still emit as usual, this is just for the common "new size came in" case.
-  (stream as any)._setSize = (cols: number, rows: number): boolean => {
-    const colsChanged = Number.isFinite(cols) && cols !== _cols;
-    const rowsChanged = Number.isFinite(rows) && rows !== _rows;
-    if (!colsChanged && !rowsChanged) return false;
-    _silent = true;
-    try {
-      if (colsChanged) (stream as any).columns = cols;
-      if (rowsChanged) (stream as any).rows = rows;
-    } finally {
-      _silent = false;
-    }
-    bus.emit("resize");
-    return true;
-  };
+    // update both at once, emit 'resize' once. individual setter assignments
+    // still emit as usual, this is just for the common "new size came in" case.
+    (stream as any)._setSize = (cols: number, rows: number): boolean => {
+      const colsChanged = Number.isFinite(cols) && cols !== _cols;
+      const rowsChanged = Number.isFinite(rows) && rows !== _rows;
+      if (!colsChanged && !rowsChanged) return false;
+      _silent = true;
+      try {
+        if (colsChanged) (stream as any).columns = cols;
+        if (rowsChanged) (stream as any).rows = rows;
+      } finally {
+        _silent = false;
+      }
+      bus.emit("resize");
+      return true;
+    };
+  }
 
   return stream;
 }

--- a/src/polyfills/process.ts
+++ b/src/polyfills/process.ts
@@ -197,6 +197,11 @@ function fabricateStream(
     if (writeFn) writeFn(text);
   };
 
+  // columns/rows live behind accessors so assigning them fires a 'resize' event,
+  // which is what TUI libs like blessed, ink, prompts etc. listen for
+  let _cols: number = DEFAULT_TERMINAL.COLUMNS;
+  let _rows: number = DEFAULT_TERMINAL.ROWS;
+
   const stream: OutputStreamBridge & InputStreamBridge = {
     isTTY: false,
     columns: DEFAULT_TERMINAL.COLUMNS,
@@ -386,7 +391,63 @@ function fabricateStream(
     };
   }
 
+  // swap the plain columns/rows properties for accessors that emit 'resize'
+  // if someone assigns the same value we don't emit, otherwise watchers get
+  // spammed on every fit() call even when the size didn't actually change
+  let _silent = false;
+  Object.defineProperty(stream, "columns", {
+    get() { return _cols; },
+    set(v: number) {
+      const n = typeof v === "number" ? v : Number(v);
+      if (!Number.isFinite(n) || n === _cols) return;
+      _cols = n;
+      if (!_silent) bus.emit("resize");
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  Object.defineProperty(stream, "rows", {
+    get() { return _rows; },
+    set(v: number) {
+      const n = typeof v === "number" ? v : Number(v);
+      if (!Number.isFinite(n) || n === _rows) return;
+      _rows = n;
+      if (!_silent) bus.emit("resize");
+    },
+    enumerable: true,
+    configurable: true,
+  });
+
+  // update both at once, emit 'resize' once. individual setter assignments
+  // still emit as usual, this is just for the common "new size came in" case.
+  (stream as any)._setSize = (cols: number, rows: number): boolean => {
+    const colsChanged = Number.isFinite(cols) && cols !== _cols;
+    const rowsChanged = Number.isFinite(rows) && rows !== _rows;
+    if (!colsChanged && !rowsChanged) return false;
+    _silent = true;
+    try {
+      if (colsChanged) (stream as any).columns = cols;
+      if (rowsChanged) (stream as any).rows = rows;
+    } finally {
+      _silent = false;
+    }
+    bus.emit("resize");
+    return true;
+  };
+
   return stream;
+}
+
+// batched size update with a single 'resize' event. used by the worker when
+// a resize message arrives from main, and by any code that wants to push a
+// new size to a TUI without firing two events.
+export function setStreamDimensions(
+  stream: { _setSize?: (c: number, r: number) => boolean } | null | undefined,
+  cols: number,
+  rows: number,
+): boolean {
+  if (!stream || typeof stream._setSize !== "function") return false;
+  return stream._setSize(cols, rows);
 }
 
 export function buildProcessEnv(config?: {

--- a/src/sdk/nodepod-terminal.ts
+++ b/src/sdk/nodepod-terminal.ts
@@ -61,13 +61,20 @@ export interface TerminalWiring {
     tokenStart: number;
     matches: string[];
   };
+  /** called after xterm reflows so the worker side (and any TUI running
+   * inside it) can update process.stdout.columns/rows and fire 'resize'. */
+  onResize?: (cols: number, rows: number) => void;
 }
 
 export class NodepodTerminal {
   private _term: any = null;
   private _fitAddon: any = null;
   private _dataDisposable: any = null;
+  private _xtermResizeDisposable: any = null;
   private _resizeHandler: (() => void) | null = null;
+  private _resizeDebounce: ReturnType<typeof setTimeout> | null = null;
+  private _lastNotifiedCols = -1;
+  private _lastNotifiedRows = -1;
 
   private _lineBuffer = "";
   private _history: string[] = [];
@@ -160,11 +167,23 @@ export class NodepodTerminal {
       const addon = this._fitAddon;
       requestAnimationFrame(() => {
         addon.fit();
-        setTimeout(() => addon.fit(), 100);
+        // second fit covers the case where the container was still
+        // laying out when the first fit ran
+        setTimeout(() => {
+          addon.fit();
+          this._notifyResize();
+        }, 100);
       });
       this._resizeHandler = () => this._fitAddon?.fit();
       window.addEventListener("resize", this._resizeHandler);
     }
+
+    // xterm fires onResize after any fit(), container size change, or
+    // manual term.resize(). debounced so dragging the window doesn't spam
+    // the worker channel.
+    this._xtermResizeDisposable = this._term.onResize?.(() => {
+      this._scheduleResizeNotify();
+    });
 
     this._dataDisposable = this._term.onData((data: string) =>
       this._handleInput(data),
@@ -173,10 +192,41 @@ export class NodepodTerminal {
     this._term.focus();
   }
 
+  private _scheduleResizeNotify(): void {
+    if (this._resizeDebounce) clearTimeout(this._resizeDebounce);
+    this._resizeDebounce = setTimeout(() => {
+      this._resizeDebounce = null;
+      this._notifyResize();
+    }, 80);
+  }
+
+  private _notifyResize(): void {
+    if (!this._term || !this._wiring?.onResize) return;
+    const cols = this._term.cols;
+    const rows = this._term.rows;
+    if (!cols || !rows) return;
+    if (cols === this._lastNotifiedCols && rows === this._lastNotifiedRows) return;
+    this._lastNotifiedCols = cols;
+    this._lastNotifiedRows = rows;
+    try {
+      this._wiring.onResize(cols, rows);
+    } catch {
+      // wiring threw, nothing we can do from the terminal side
+    }
+  }
+
   detach(): void {
     if (this._dataDisposable) {
       this._dataDisposable.dispose();
       this._dataDisposable = null;
+    }
+    if (this._xtermResizeDisposable) {
+      this._xtermResizeDisposable.dispose?.();
+      this._xtermResizeDisposable = null;
+    }
+    if (this._resizeDebounce) {
+      clearTimeout(this._resizeDebounce);
+      this._resizeDebounce = null;
     }
     if (this._resizeHandler) {
       window.removeEventListener("resize", this._resizeHandler);

--- a/src/sdk/nodepod.ts
+++ b/src/sdk/nodepod.ts
@@ -371,10 +371,21 @@ export class Nodepod {
         env: this._env,
       });
       shellReady = new Promise<void>((resolve) => {
+        const seedSize = () => {
+          // seed size before the first exec so interactive CLIs see real
+          // dimensions instead of the 80x24 worker defaults
+          if (lastCols && lastRows && shellHandle) {
+            shellHandle.resize(lastCols, lastRows);
+          }
+        };
         if (shellHandle!.state === "running") {
+          seedSize();
           resolve();
         } else {
-          shellHandle!.on("ready", () => resolve());
+          shellHandle!.on("ready", () => {
+            seedSize();
+            resolve();
+          });
         }
       });
 
@@ -394,6 +405,21 @@ export class Nodepod {
       });
 
       return shellReady;
+    };
+
+    // last known size, sent to the shell worker as soon as it boots so the
+    // first command sees the real dimensions instead of 80x24 defaults
+    let lastCols = 0;
+    let lastRows = 0;
+
+    const forwardResize = (cols: number, rows: number) => {
+      lastCols = cols;
+      lastRows = rows;
+      // fire and forget. if no shell exists yet, the size is seeded via
+      // the "ready" handler below so the first exec picks it up.
+      if (shellHandle && shellHandle.state !== "exited") {
+        shellHandle.resize(cols, rows);
+      }
     };
 
     terminal._wireExecution({
@@ -527,6 +553,7 @@ export class Nodepod {
       },
       getCompletions: (line: string, cursorPos: number, cwd: string) =>
         getCompletions(line, cursorPos, cwd, this._volume, shellBuiltins.keys()),
+      onResize: forwardResize,
     });
 
     return terminal;

--- a/src/threading/process-worker-entry.ts
+++ b/src/threading/process-worker-entry.ts
@@ -82,6 +82,15 @@ self.addEventListener("message", (ev: MessageEvent) => {
     case "resize":
       _cols = msg.cols;
       _rows = msg.rows;
+      // push to the currently running script's process.stdout/stderr/stdin
+      // so TUI libraries (blessed, ink etc.) get a 'resize' event mid-run
+      if (_shellMod) {
+        try {
+          _shellMod.notifyTerminalResize?.(msg.cols, msg.rows);
+        } catch {
+          // swallow, size sync isn't critical enough to crash the worker
+        }
+      }
       break;
     case "vfs-sync":
       handleVFSSync(msg);


### PR DESCRIPTION
closes #26

## what

wires NodepodTerminal's FitAddon up to the worker so xterm reflows actually reach the running script. `process.stdout` and `process.stderr` get a real `'resize'` event whenever cols or rows change, which is what blessed, ink, prompts, etc. listen for.

## what was missing

most of the plumbing was already there. `worker-protocol.ts` had a Resize message, `ProcessHandle.resize(cols, rows)` existed, and the worker entry already tracked `_cols/_rows` internally. `child_process` was reading those at executeNodeBinary start, so spawned subprocesses would pick up the right initial size if anything called `handle.resize()`. three gaps:

- nothing bridged the terminal to the worker. `TerminalWiring` had no `onResize` callback and `createTerminal()` never called `handle.resize()`, so FitAddon reflowed xterm locally and the info died there
- `fabricateStream()` set columns/rows at construction and never updated them, plus never emitted `'resize'`. so even if the size reached the worker, the running script's `process.stdout` wouldn't know
- `isTTY` was only `true` for spawned subprocesses, not the top-level shell's own `process.stdout`

## what changed

- new `onResize` hook on `TerminalWiring`, debounced ~80ms so dragging the window doesn't spam the worker channel, with dedup on identical dimensions
- `createTerminal()` forwards it via `handle.resize()` and seeds the size as soon as a fresh shell worker boots, so the first command already sees the real dimensions
- `fabricateStream()` swaps columns/rows for accessors that emit `'resize'` on change, plus a batched `_setSize` helper. only installed on output streams because real Node's `tty.ReadStream` (stdin) has no columns/rows and never fires resize
- `child_process` keeps a set of active node procs so the worker can push size updates to every running script on resize
- `process-worker-entry`'s resize handler now also calls `notifyTerminalResize` so TUIs already running react mid-flight, not just at startup
- added `examples/terminal-resize` with a tiny TUI that redraws when `process.stdout` fires `'resize'`, plus a live size badge and event log

## node accuracy

double checked against real Node.js source (`lib/tty.js`):

- both stdout and stderr emit `'resize'` in Node, each WriteStream installs its own SIGWINCH handler. this PR matches
- stdin does NOT emit `'resize'` in Node, tty.ReadStream has no such event. this PR matches (tests lock it in)
- Node's `_refreshSize()` skips the emit when cols/rows didn't actually change. this PR matches via dedup in the setter

## test plan

- [x] `npm run type-check` clean
- [x] `npm test` 460 passed (added 7 new tests covering the assignment path, batched helper, dedup, NaN rejection, stderr-yes, stdin-no)
- [x] `npm run build:lib` produces a fresh dist
- [x] open `examples/terminal-resize/`, run `node tui.js`, drag the window edge, confirm the TUI redraws and the size badge updates live
