### PR TITLE
feat(event-loop): add libuv-parity HandleRegistry

### DIFF
--- a/src/__tests__/event-loop.test.ts
+++ b/src/__tests__/event-loop.test.ts
@@ -1,0 +1,269 @@
+// unit tests for HandleRegistry + Handle in src/helpers/event-loop.ts.
+// covers the libuv-parity invariants: typed handles, O(1) refed count,
+// idempotent close, drain-promise re-arming, beforeExit emission.
+
+import { describe, it, expect } from "vitest";
+import {
+  createHandleRegistry,
+  getRegistry,
+  getGlobalRegistry,
+} from "../helpers/event-loop";
+
+describe("HandleRegistry - basics", () => {
+  it("register bumps the refed count when refed=true (default)", () => {
+    const r = createHandleRegistry();
+    const h = r.register("Timeout");
+    expect(r.activeRefedCount()).toBe(1);
+    expect(h.refed).toBe(true);
+    expect(h.type).toBe("Timeout");
+    h.close();
+  });
+
+  it("register with refed=false does not bump the count", () => {
+    const r = createHandleRegistry();
+    const h = r.register("Timeout", { refed: false });
+    expect(r.activeRefedCount()).toBe(0);
+    expect(h.refed).toBe(false);
+    // but it's still listed
+    expect(r.list().length).toBe(1);
+    h.close();
+  });
+
+  it("ref() / unref() flip the flag and the counter", () => {
+    const r = createHandleRegistry();
+    const h = r.register("Timeout", { refed: false });
+    expect(r.activeRefedCount()).toBe(0);
+    h.ref();
+    expect(h.refed).toBe(true);
+    expect(r.activeRefedCount()).toBe(1);
+    h.unref();
+    expect(h.refed).toBe(false);
+    expect(r.activeRefedCount()).toBe(0);
+    h.close();
+  });
+
+  it("ref() is idempotent, second call does not double-count", () => {
+    const r = createHandleRegistry();
+    const h = r.register("Timeout");
+    h.ref();
+    h.ref();
+    expect(r.activeRefedCount()).toBe(1);
+    h.close();
+  });
+
+  it("unref() on an unref'd handle is idempotent", () => {
+    const r = createHandleRegistry();
+    const h = r.register("Timeout");
+    h.unref();
+    h.unref();
+    expect(r.activeRefedCount()).toBe(0);
+    h.close();
+  });
+
+  it("close() is idempotent, second call is a no-op", () => {
+    const r = createHandleRegistry();
+    const h = r.register("Timeout");
+    h.close();
+    h.close(); // should not go negative or remove something already gone
+    expect(r.activeRefedCount()).toBe(0);
+    expect(r.list().length).toBe(0);
+  });
+
+  it("close() on a refed handle auto-unrefs", () => {
+    const r = createHandleRegistry();
+    const h = r.register("Timeout");
+    expect(r.activeRefedCount()).toBe(1);
+    h.close();
+    expect(r.activeRefedCount()).toBe(0);
+    expect(h.closed).toBe(true);
+  });
+
+  it("ref()/unref() on a closed handle are no-ops", () => {
+    const r = createHandleRegistry();
+    const h = r.register("Timeout");
+    h.close();
+    h.ref();
+    expect(r.activeRefedCount()).toBe(0);
+    h.unref();
+    expect(r.activeRefedCount()).toBe(0);
+  });
+});
+
+describe("HandleRegistry - list + groupedByType", () => {
+  it("list() returns all registered handles (refed or not)", () => {
+    const r = createHandleRegistry();
+    const a = r.register("Timeout");
+    const b = r.register("HTTPServer", { refed: false });
+    expect(r.list().length).toBe(2);
+    a.close();
+    b.close();
+    expect(r.list().length).toBe(0);
+  });
+
+  it("groupedByType() counts only refed handles, keyed by type string", () => {
+    const r = createHandleRegistry();
+    r.register("Timeout");
+    r.register("Timeout");
+    r.register("HTTPServer");
+    const h = r.register("FetchRequest");
+    h.unref();
+    const grouped = r.groupedByType();
+    expect(grouped.Timeout).toBe(2);
+    expect(grouped.HTTPServer).toBe(1);
+    expect(grouped.FetchRequest).toBeUndefined(); // unref'd
+  });
+});
+
+describe("HandleRegistry - drainPromise", () => {
+  it("resolves immediately when count is already 0", async () => {
+    const r = createHandleRegistry();
+    await expect(r.drainPromise()).resolves.toBeUndefined();
+  });
+
+  it("resolves on 1 -> 0 transition", async () => {
+    const r = createHandleRegistry();
+    const h = r.register("Timeout");
+    const p = r.drainPromise();
+    let resolved = false;
+    p.then(() => {
+      resolved = true;
+    });
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+    h.close();
+    // microtask turn for .then to fire
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(resolved).toBe(true);
+  });
+
+  it("re-arms: a fresh promise is returned after drain", async () => {
+    const r = createHandleRegistry();
+    const h1 = r.register("Timeout");
+    const p1 = r.drainPromise();
+    h1.close();
+    await p1;
+
+    const h2 = r.register("Timeout");
+    const p2 = r.drainPromise();
+    expect(p1).not.toBe(p2);
+    let resolved = false;
+    p2.then(() => {
+      resolved = true;
+    });
+    h2.close();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(resolved).toBe(true);
+  });
+
+  it("does not resolve on unref-then-re-ref staying above zero", async () => {
+    const r = createHandleRegistry();
+    const a = r.register("Timeout");
+    const b = r.register("Timeout");
+    const p = r.drainPromise();
+    let resolved = false;
+    p.then(() => {
+      resolved = true;
+    });
+    a.close(); // count 2 -> 1, no transition to 0
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+    b.close();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(resolved).toBe(true);
+  });
+});
+
+describe("HandleRegistry - onDrain callbacks", () => {
+  it("fires registered onDrain callbacks on transition to 0", () => {
+    const r = createHandleRegistry();
+    const h = r.register("Timeout");
+    let calls = 0;
+    r.onDrain(() => {
+      calls++;
+    });
+    h.close();
+    expect(calls).toBe(1);
+  });
+
+  it("disposer removes the callback", () => {
+    const r = createHandleRegistry();
+    const h = r.register("Timeout");
+    let calls = 0;
+    const dispose = r.onDrain(() => {
+      calls++;
+    });
+    dispose();
+    h.close();
+    expect(calls).toBe(0);
+  });
+});
+
+describe("HandleRegistry - beforeExit", () => {
+  it("emitBeforeExit awaits sequential handlers", async () => {
+    const r = createHandleRegistry();
+    const order: number[] = [];
+    r.onBeforeExit(async (code) => {
+      await new Promise((res) => setTimeout(res, 5));
+      order.push(1);
+      expect(code).toBe(0);
+    });
+    r.onBeforeExit(async () => {
+      order.push(2);
+    });
+    await r.emitBeforeExit(0);
+    expect(order).toEqual([1, 2]);
+  });
+
+  it("swallows handler errors (matches node exit-time semantics)", async () => {
+    const r = createHandleRegistry();
+    r.onBeforeExit(() => {
+      throw new Error("boom");
+    });
+    let reached = false;
+    r.onBeforeExit(() => {
+      reached = true;
+    });
+    await r.emitBeforeExit(0);
+    expect(reached).toBe(true);
+  });
+
+  it("disposer removes the beforeExit handler", async () => {
+    const r = createHandleRegistry();
+    let calls = 0;
+    const dispose = r.onBeforeExit(() => {
+      calls++;
+    });
+    dispose();
+    await r.emitBeforeExit(0);
+    expect(calls).toBe(0);
+  });
+});
+
+describe("HandleRegistry - closeAll", () => {
+  it("closes every outstanding handle and zeroes the counter", () => {
+    const r = createHandleRegistry();
+    r.register("Timeout");
+    r.register("HTTPServer");
+    r.register("FetchRequest", { refed: false });
+    expect(r.list().length).toBe(3);
+    r.closeAll();
+    expect(r.list().length).toBe(0);
+    expect(r.activeRefedCount()).toBe(0);
+  });
+});
+
+describe("event-loop module - global registry", () => {
+  it("getGlobalRegistry returns a stable registry", () => {
+    const a = getGlobalRegistry();
+    const b = getGlobalRegistry();
+    expect(a).toBe(b);
+  });
+
+  it("getRegistry falls back to the global registry with no active context", () => {
+    expect(getRegistry()).toBe(getGlobalRegistry());
+  });
+});

--- a/src/__tests__/exit-semantics.test.ts
+++ b/src/__tests__/exit-semantics.test.ts
@@ -1,0 +1,690 @@
+// end-to-end exit-semantics tests. runs scripts through executeNodeBinary
+// (same path `node /script.js` takes from the shell) and asserts timing +
+// output invariants that have to match node.
+//
+// these exist because the old tiered-timeout wait loop had no coverage. it
+// silently mis-exited on long timers, stalled on finished scripts, and
+// killed slow async startups. the Handle-Registry rework (event-loop.ts)
+// swapped that out for a libuv-parity drain-promise model; these guard it.
+
+import { describe, it, expect } from "vitest";
+import { MemoryVolume } from "../memory-volume";
+import {
+  executeNodeBinary,
+  initShellExec,
+} from "../polyfills/child_process";
+import type { ShellContext } from "../shell/shell-types";
+
+function setup(files: Record<string, string>) {
+  const vol = new MemoryVolume();
+  for (const [path, content] of Object.entries(files)) {
+    const dir = path.substring(0, path.lastIndexOf("/")) || "/";
+    if (dir !== "/") vol.mkdirSync(dir, { recursive: true });
+    vol.writeFileSync(path, content);
+  }
+  // wires volume into child_process so executeNodeBinary works
+  initShellExec(vol, { cwd: "/" });
+  const ctx: ShellContext = {
+    cwd: "/",
+    env: { HOME: "/home", PATH: "/usr/bin", PWD: "/" },
+    volume: vol,
+    exec: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
+  };
+  return { vol, ctx };
+}
+
+// generous slop for CI / windows timer jitter
+const SLOP_MS = 300;
+
+describe("exit semantics - libuv-parity", () => {
+  describe("exit latency", () => {
+    it("empty script exits immediately (< 200 ms)", async () => {
+      const { ctx } = setup({
+        "/empty.js": `console.log("hi");`,
+      });
+      const t0 = performance.now();
+      const r = await executeNodeBinary("/empty.js", [], ctx);
+      const elapsed = performance.now() - t0;
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toContain("hi");
+      expect(elapsed).toBeLessThan(200);
+    });
+
+    it("script with process.exit(0) exits immediately", async () => {
+      const { ctx } = setup({
+        "/exit.js": `console.log("bye"); process.exit(0);`,
+      });
+      const t0 = performance.now();
+      const r = await executeNodeBinary("/exit.js", [], ctx);
+      const elapsed = performance.now() - t0;
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toContain("bye");
+      expect(elapsed).toBeLessThan(200);
+    });
+  });
+
+  describe("timers keep the loop alive", () => {
+    it("setTimeout(fn, 300) fires before exit", async () => {
+      const { ctx } = setup({
+        "/timer.js": `setTimeout(() => console.log("late"), 300);`,
+      });
+      const t0 = performance.now();
+      const r = await executeNodeBinary("/timer.js", [], ctx);
+      const elapsed = performance.now() - t0;
+      expect(r.stdout).toContain("late");
+      expect(elapsed).toBeGreaterThanOrEqual(300 - 50);
+      expect(elapsed).toBeLessThan(300 + SLOP_MS + 400);
+    });
+
+    it("unref'd timer does NOT keep the loop alive", async () => {
+      const { ctx } = setup({
+        "/unref.js": `
+          const t = setTimeout(() => console.log("BAD"), 3000);
+          t.unref();
+          console.log("ok");
+        `,
+      });
+      const t0 = performance.now();
+      const r = await executeNodeBinary("/unref.js", [], ctx);
+      const elapsed = performance.now() - t0;
+      expect(r.stdout).toContain("ok");
+      expect(r.stdout).not.toContain("BAD");
+      // exits long before the 3 s timer would fire
+      expect(elapsed).toBeLessThan(500);
+    });
+
+    it("clearTimeout releases the handle and exit is prompt", async () => {
+      const { ctx } = setup({
+        "/cleared.js": `
+          const t = setTimeout(() => console.log("BAD"), 5000);
+          clearTimeout(t);
+          console.log("cleared");
+        `,
+      });
+      const t0 = performance.now();
+      const r = await executeNodeBinary("/cleared.js", [], ctx);
+      const elapsed = performance.now() - t0;
+      expect(r.stdout).toContain("cleared");
+      expect(r.stdout).not.toContain("BAD");
+      expect(elapsed).toBeLessThan(500);
+    });
+
+    it("long timer (>5s tier-3-timeout regression) fires", async () => {
+      // the old tier-3 timeout killed anything past 5s if refs dipped to 0
+      // and back. with Handle tracking a 5.5s timer just fires.
+      const { ctx } = setup({
+        "/long.js": `setTimeout(() => console.log("woke"), 5500);`,
+      });
+      const t0 = performance.now();
+      const r = await executeNodeBinary("/long.js", [], ctx);
+      const elapsed = performance.now() - t0;
+      expect(r.stdout).toContain("woke");
+      expect(elapsed).toBeGreaterThanOrEqual(5500 - 50);
+      expect(elapsed).toBeLessThan(5500 + SLOP_MS + 500);
+    }, 15_000);
+  });
+
+  describe("beforeExit", () => {
+    it("fires on natural drain", async () => {
+      const { ctx } = setup({
+        "/be.js": `
+          process.on("beforeExit", (code) => console.log("bye-" + code));
+          console.log("start");
+        `,
+      });
+      const r = await executeNodeBinary("/be.js", [], ctx);
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toContain("start");
+      expect(r.stdout).toContain("bye-0");
+    });
+
+    it("does NOT fire on process.exit()", async () => {
+      const { ctx } = setup({
+        "/nobe.js": `
+          process.on("beforeExit", () => console.log("SHOULD_NOT_PRINT"));
+          console.log("start");
+          process.exit(0);
+        `,
+      });
+      const r = await executeNodeBinary("/nobe.js", [], ctx);
+      expect(r.stdout).toContain("start");
+      expect(r.stdout).not.toContain("SHOULD_NOT_PRINT");
+    });
+
+    it("handler that schedules more work re-enters the loop", async () => {
+      const { ctx } = setup({
+        "/revive.js": `
+          let fired = 0;
+          process.on("beforeExit", () => {
+            fired++;
+            if (fired === 1) setTimeout(() => console.log("rescheduled"), 50);
+          });
+          console.log("start");
+        `,
+      });
+      const r = await executeNodeBinary("/revive.js", [], ctx);
+      expect(r.stdout).toContain("start");
+      expect(r.stdout).toContain("rescheduled");
+    });
+  });
+
+  describe("create-qwik pattern (CJS + unawaited async + wait(500))", () => {
+    it("via shellExec (closer to real `npm create qwik` path)", async () => {
+      // same script but invoked through initShellExec's shell (has node + npm
+      // commands). exercises the full shell-interpreter -> node-command ->
+      // executeNodeBinary chain.
+      const { shellExec } = await import("../polyfills/child_process");
+      setup({
+        "/main.cjs": `
+          function wait(ms) { return new Promise(r => setTimeout(r, ms)); }
+          exports.runCli = async function runCli() {
+            console.log("banner");
+            await wait(500);
+            console.log("after-wait");
+          };
+        `,
+        "/entry.cjs": `
+          const mod = require("./main.cjs");
+          mod.runCli();
+        `,
+      });
+      const t0 = performance.now();
+      const result = await new Promise<{ stdout: string; stderr: string; exitCode: number }>((resolve) => {
+        shellExec("node /entry.cjs", {}, (err, stdout, stderr) => {
+          resolve({
+            stdout: String(stdout ?? ""),
+            stderr: String(stderr ?? ""),
+            exitCode: err ? ((err as any).code ?? 1) : 0,
+          });
+        });
+      });
+      const elapsed = performance.now() - t0;
+      expect(result.stdout).toContain("banner");
+      expect(result.stdout).toContain("after-wait");
+      expect(elapsed).toBeGreaterThanOrEqual(500 - 50);
+    }, 5_000);
+
+    it("deep async chain: unawaited runCli with multiple awaits before setTimeout", async () => {
+      // matches create-qwik exactly:
+      //   runCli()  async, not awaited
+      //     await makeTemplateManager()   first yield, no handle yet
+      //       await loadIntegrations()    deeper yield
+      //         await fs.promises.readdir even deeper, microtask-resolved
+      //     intro(banner)
+      //     await wait(500)               finally a setTimeout that refs
+      // a naive single-microtask drain exits before we reach setTimeout.
+      const { ctx } = setup({
+        "/entry.cjs": `
+          async function fakeReaddir() { return ['a','b','c']; }
+          async function loadIntegrations() {
+            const items = await fakeReaddir();
+            const checked = await Promise.all(items.map(async () => {
+              const inner = await fakeReaddir();
+              return inner.length;
+            }));
+            return checked;
+          }
+          async function makeTemplateManager() {
+            const ints = await loadIntegrations();
+            return { count: ints.length };
+          }
+          function wait(ms) { return new Promise(r => setTimeout(r, ms)); }
+          async function runCli() {
+            const tm = await makeTemplateManager();
+            console.log("banner", tm.count);
+            await wait(500);
+            console.log("after-wait");
+          }
+          runCli();
+        `,
+      });
+      const t0 = performance.now();
+      const r = await executeNodeBinary("/entry.cjs", [], ctx);
+      const elapsed = performance.now() - t0;
+      expect(r.stdout).toContain("banner");
+      expect(r.stdout).toContain("after-wait");
+      expect(elapsed).toBeGreaterThanOrEqual(500 - 50);
+    }, 5_000);
+
+    it("unawaited async function call keeps loop alive while awaiting setTimeout-based sleep", async () => {
+      // mirrors create-qwik's structure:
+      //   entry.cjs: require('./main'); main.runCli();   // NOT awaited
+      //   main.cjs: exports.runCli = async () => { ...; await wait(500); ... };
+      //   wait(ms): new Promise(r => setTimeout(r, ms));
+      //
+      // entry is sync CJS so TLA resolves immediately. between sync entry
+      // return and runCli's setTimeout Handle register there's a microtask
+      // gap. if the wait loop exits in that gap, "after-wait" never prints.
+      const { ctx } = setup({
+        "/main.cjs": `
+          function wait(ms) { return new Promise(r => setTimeout(r, ms)); }
+          exports.runCli = async function runCli() {
+            console.log("banner");
+            await wait(500);
+            console.log("after-wait");
+          };
+        `,
+        "/entry.cjs": `
+          const mod = require("./main.cjs");
+          mod.runCli();
+        `,
+      });
+      const t0 = performance.now();
+      const r = await executeNodeBinary("/entry.cjs", [], ctx);
+      const elapsed = performance.now() - t0;
+      expect(r.stdout).toContain("banner");
+      expect(r.stdout).toContain("after-wait");
+      expect(elapsed).toBeGreaterThanOrEqual(500 - 50);
+    }, 5_000);
+  });
+
+  describe("node-parity correctness fixes", () => {
+    it("process.exitCode is honored on natural drain", async () => {
+      const { ctx } = setup({
+        "/exitCode.js": `
+          process.exitCode = 42;
+          console.log("hi");
+          // no explicit process.exit, natural drain
+        `,
+      });
+      const r = await executeNodeBinary("/exitCode.js", [], ctx);
+      expect(r.stdout).toContain("hi");
+      expect(r.exitCode).toBe(42);
+    });
+
+    it("beforeExit handler receives process.exitCode (not 0)", async () => {
+      const { ctx } = setup({
+        "/be-code.js": `
+          process.exitCode = 7;
+          process.on("beforeExit", (c) => console.log("be-code=" + c));
+          console.log("start");
+        `,
+      });
+      const r = await executeNodeBinary("/be-code.js", [], ctx);
+      expect(r.stdout).toContain("start");
+      expect(r.stdout).toContain("be-code=7");
+      expect(r.exitCode).toBe(7);
+    });
+
+    it("'exit' event fires on natural drain", async () => {
+      const { ctx } = setup({
+        "/exit-evt.js": `
+          process.on("exit", (c) => console.log("exit=" + c));
+          console.log("start");
+        `,
+      });
+      const r = await executeNodeBinary("/exit-evt.js", [], ctx);
+      expect(r.stdout).toContain("start");
+      expect(r.stdout).toContain("exit=0");
+    });
+
+    it("'exit' event fires only once when process.exit() is called", async () => {
+      const { ctx } = setup({
+        "/exit-once.js": `
+          let count = 0;
+          process.on("exit", () => { count++; console.log("exit-count=" + count); });
+          console.log("start");
+          process.exit(3);
+        `,
+      });
+      const r = await executeNodeBinary("/exit-once.js", [], ctx);
+      expect(r.stdout).toContain("start");
+      // exactly one exit emission
+      const matches = r.stdout.match(/exit-count=/g) ?? [];
+      expect(matches.length).toBe(1);
+      expect(r.stdout).toContain("exit-count=1");
+      expect(r.exitCode).toBe(3);
+    });
+
+    it("process.exit() inside a beforeExit handler short-circuits remaining handlers", async () => {
+      const { ctx } = setup({
+        "/be-exit.js": `
+          process.on("beforeExit", () => {
+            console.log("first");
+            process.exit(5);
+            console.log("after-exit-NEVER");
+          });
+          process.on("beforeExit", () => {
+            console.log("second-NEVER");
+          });
+          console.log("start");
+        `,
+      });
+      const r = await executeNodeBinary("/be-exit.js", [], ctx);
+      expect(r.stdout).toContain("start");
+      expect(r.stdout).toContain("first");
+      expect(r.stdout).not.toContain("after-exit-NEVER");
+      expect(r.stdout).not.toContain("second-NEVER");
+      expect(r.exitCode).toBe(5);
+    });
+
+    it("process.exit() from a setTimeout callback wakes the wait loop", async () => {
+      // regression for vite's q + Enter shortcut. the keypress handler (a
+      // setTimeout-style async callback) does `await server.close(); process.exit()`.
+      // after server.close, the readline still holds stdin's TTYWrap handle.
+      // without an exitPromise in the wait loop's race, process.exit flips
+      // didExit=true but the loop keeps waiting on drainPromise (which never
+      // resolves because of the readline) and the process hangs.
+      const { ctx } = setup({
+        "/late-exit.js": `
+          const readline = require("node:readline");
+          // create a readline so stdin TTYWrap stays referenced
+          const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+          readline.emitKeypressEvents(process.stdin, rl);
+          // exit after 100ms, readline never closed. mimics vite's q+Enter
+          // race where the keypress handler calls process.exit without closing
+          // the readline first.
+          setTimeout(() => {
+            console.log("about-to-exit");
+            process.exit(0);
+          }, 100);
+          console.log("waiting");
+        `,
+      });
+      const t0 = performance.now();
+      const r = await executeNodeBinary("/late-exit.js", [], ctx);
+      const elapsed = performance.now() - t0;
+      expect(r.stdout).toContain("waiting");
+      expect(r.stdout).toContain("about-to-exit");
+      expect(r.exitCode).toBe(0);
+      // should exit within ~100ms + slop, not hang
+      expect(elapsed).toBeLessThan(500);
+    });
+
+    it("readline.close() removes its listeners (no leak across sequential readlines)", async () => {
+      // create-vite opens a readline for each prompt and closes it. if close
+      // leaks listeners, stdin piles up dead handlers across the script's life.
+      const { ctx } = setup({
+        "/seq-rl.js": `
+          const readline = require("node:readline");
+          for (let i = 0; i < 3; i++) {
+            const rl = readline.createInterface({ input: process.stdin, output: process.stdout, terminal: true });
+            rl.close();
+          }
+          const remaining = process.stdin.listenerCount("keypress");
+          console.log("keypress-listeners=" + remaining);
+        `,
+      });
+      const r = await executeNodeBinary("/seq-rl.js", [], ctx);
+      // each rl adds one keypress listener; close should remove it. the
+      // permanent emitKeypressEvents data->keypress decoder sits on 'data',
+      // not 'keypress', so it doesn't count here.
+      expect(r.stdout).toContain("keypress-listeners=0");
+    });
+
+    it("readline.Interface.close() releases stdin so process exits", async () => {
+      // @clack/prompts creates readlines, attaches data listeners to stdin
+      // (via emitKeypressEvents), then closes the readline. if close doesn't
+      // pause stdin, the TTYWrap handle stays active forever and the process
+      // hangs after the script is "done".
+      const { ctx } = setup({
+        "/rl.js": `
+          const readline = require("node:readline");
+          const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+          // simulate @clack: attach a data listener via emitKeypressEvents
+          readline.emitKeypressEvents(process.stdin, rl);
+          // user does some work here
+          rl.close();
+          console.log("rl-closed");
+        `,
+      });
+      const t0 = performance.now();
+      const r = await executeNodeBinary("/rl.js", [], ctx);
+      const elapsed = performance.now() - t0;
+      expect(r.stdout).toContain("rl-closed");
+      // should exit promptly after rl.close()
+      expect(elapsed).toBeLessThan(500);
+    });
+
+    it("setTimeout(fn, 5000).unref() lets process exit promptly", async () => {
+      // already covered by timer tests but keeping an explicit node-parity check
+      const { ctx } = setup({
+        "/unref-prompt.js": `
+          const t = setTimeout(() => console.log("BAD"), 5000);
+          t.unref();
+          console.log("ok");
+        `,
+      });
+      const t0 = performance.now();
+      const r = await executeNodeBinary("/unref-prompt.js", [], ctx);
+      const elapsed = performance.now() - t0;
+      expect(r.stdout).toContain("ok");
+      expect(r.stdout).not.toContain("BAD");
+      expect(elapsed).toBeLessThan(500);
+    });
+  });
+
+  describe("process.getActiveResourcesInfo()", () => {
+    it("returns live Handle types for pending timers", async () => {
+      const { ctx } = setup({
+        "/info.js": `
+          setTimeout(() => {}, 100);
+          setTimeout(() => {}, 100);
+          console.log(JSON.stringify(process.getActiveResourcesInfo()));
+        `,
+      });
+      const r = await executeNodeBinary("/info.js", [], ctx);
+      // expect some Timeout entries in the refed list (plus whatever the
+      // runtime itself is holding at that moment)
+      expect(r.stdout).toMatch(/Timeout/);
+    });
+
+    it("omits unref'd handles", async () => {
+      const { ctx } = setup({
+        "/info2.js": `
+          const t = setTimeout(() => {}, 5000);
+          t.unref();
+          console.log(JSON.stringify(process.getActiveResourcesInfo()));
+        `,
+      });
+      const r = await executeNodeBinary("/info2.js", [], ctx);
+      // find the JSON array line in stdout and parse it
+      const arrLine = r.stdout
+        .split("\n")
+        .map((s) => s.trim())
+        .find((l) => l.startsWith("[") && l.endsWith("]"));
+      expect(arrLine).toBeTruthy();
+      const parsed = JSON.parse(arrLine!) as string[];
+      // the unref'd timer should not be in the refed list
+      expect(parsed).not.toContain("Timeout");
+    });
+  });
+
+  describe("vite `q`-shortcut pattern", () => {
+    // vite v5's quit shortcut is:
+    //   try { await server.close(); } finally { process.exit(); }
+    // server.close awaits Promise.allSettled([...]) of watcher.close,
+    // hot.close, container.close, and closeHttpServer. key bit is that
+    // process.exit runs inside finally and has to wake the wait loop even
+    // if some handle (bundled ws heartbeat, etc) survives the close.
+    // regression test for the "q presses stop the server but terminal hangs"
+    // bug.
+    it("process.exit() in finally wakes wait loop even with leaked handle", async () => {
+      const { ctx } = setup({
+        "/vite-like.js": `
+          const http = require("node:http");
+          const readline = require("node:readline");
+
+          const server = http.createServer((req, res) => { res.end("ok"); });
+          server.listen(0);
+
+          const rl = readline.createInterface({ input: process.stdin });
+          server.on("close", () => rl.close());
+
+          // leaked handle: interval the shutdown path never clears (mirrors
+          // vite's bundled HMR heartbeat if its close path misses something).
+          // forces the wait loop to exit via process.exit, not natural drain.
+          setInterval(() => {}, 1000);
+
+          setTimeout(async () => {
+            try {
+              await Promise.allSettled([
+                new Promise((r) => setTimeout(r, 10)),
+                new Promise((r) => setTimeout(r, 15)),
+                new Promise((r) => server.close(r)),
+              ]);
+            } finally {
+              process.exit();
+            }
+          }, 50);
+
+          console.log("ready");
+        `,
+      });
+
+      const t0 = performance.now();
+      const r = await executeNodeBinary("/vite-like.js", [], ctx);
+      const elapsed = performance.now() - t0;
+
+      expect(r.stdout).toContain("ready");
+      // must exit, not hang. shutdown is scheduled at t+50ms, allSettled
+      // waits ~15ms for the slowest inner timer, so ~70ms is the floor.
+      // 1.5s safety margin before we call it a hang.
+      expect(elapsed).toBeLessThan(1500);
+      expect(r.exitCode).toBe(0);
+    }, 5000);
+
+    // chokidar.close awaits a 'close' event from each underlying fs.watch
+    // handle. without that event chokidar.close never resolves, vite's
+    // Promise.allSettled([watcher.close(), ...]) hangs, finally never runs
+    // and the terminal stays stuck. this guards the node-parity 'close' emit.
+    it("fs.watch handle emits 'close' event when close() is called", async () => {
+      const { ctx } = setup({
+        "/watch-close.js": `
+          const fs = require("node:fs");
+          fs.writeFileSync("/target.txt", "x");
+          const w = fs.watch("/target.txt", () => {});
+          let got = false;
+          w.on("close", () => { got = true; });
+          w.close();
+          // setTimeout(0) lets any deferred emit settle
+          setTimeout(() => {
+            console.log("closeEmitted=" + got);
+            process.exit(got ? 0 : 1);
+          }, 0);
+        `,
+      });
+      const r = await executeNodeBinary("/watch-close.js", [], ctx);
+      expect(r.stdout).toContain("closeEmitted=true");
+      expect(r.exitCode).toBe(0);
+    });
+
+    // exact vite pattern: readline fires 'line', async handler does
+    // `await server.close()` where inner allSettled hangs. before the
+    // EventEmitter fix this hung because the async listener's Promise was
+    // tracked in the registry. now the dangling listener promise is ignored
+    // and refs drain to 0 via handle closure, loop exits naturally.
+    it("vite pattern: readline 'line' -> async handler with hanging await -> natural exit", async () => {
+      const { ctx } = setup({
+        "/vite-exact.js": `
+          const http = require("node:http");
+          const readline = require("node:readline");
+
+          const server = http.createServer((_req, res) => res.end("ok"));
+          server.listen(0);
+
+          const rl = readline.createInterface({ input: process.stdin });
+          server.on("close", () => rl.close());
+
+          rl.on("line", async (line) => {
+            if (line !== "q") return;
+            // mirror vite: one inner promise never resolves
+            await Promise.allSettled([
+              new Promise(() => {}),               // never resolves (vite's _pendingRequests)
+              new Promise((r) => server.close(r)), // http close, sync microtask
+            ]);
+            // unreachable if the above hangs forever, which is the whole point.
+            // in real node the hanging promise doesn't keep the loop alive
+            // because the OTHER handles close, registry drains, exit.
+          });
+
+          // fake the user pressing q by emitting on the stdin bus directly
+          setTimeout(() => process.stdin.emit("data", "q\\n"), 30);
+        `,
+      });
+      const t0 = performance.now();
+      const r = await executeNodeBinary("/vite-exact.js", [], ctx);
+      const elapsed = performance.now() - t0;
+      expect(r.exitCode).toBe(0);
+      // if fire-and-forget is working we exit promptly even though the
+      // listener's await is forever-pending.
+      expect(elapsed).toBeLessThan(1000);
+    }, 5000);
+
+    // regression for the vite-q hang. our EventEmitter used to register a
+    // Handle per async-listener promise, so any listener returning a
+    // never-settling promise leaked a refed Handle forever. node's
+    // EventEmitter is fire-and-forget: returned promises aren't awaited and
+    // don't keep the loop alive. this asserts that parity.
+    it("EventEmitter async listener returning a never-settling Promise does NOT keep loop alive", async () => {
+      const { ctx } = setup({
+        "/ee-async.js": `
+          const { EventEmitter } = require("node:events");
+          const ee = new EventEmitter();
+          // async listener whose promise never resolves. classic "pending
+          // module transform" pattern that was hanging vite's q handler.
+          ee.on("signal", async () => {
+            await new Promise(() => {});  // never resolves
+          });
+          ee.emit("signal");
+          console.log("after-emit");
+        `,
+      });
+      const t0 = performance.now();
+      const r = await executeNodeBinary("/ee-async.js", [], ctx);
+      const elapsed = performance.now() - t0;
+      expect(r.stdout).toContain("after-emit");
+      expect(r.exitCode).toBe(0);
+      // must exit promptly. if the listener's promise is keeping the loop
+      // alive, this would hang past the 5s test timeout.
+      expect(elapsed).toBeLessThan(500);
+    });
+
+    // chokidar wraps each fs.watch handle in a promise that resolves when
+    // it emits 'close'. chokidar.close returns Promise.all(closers). if any
+    // closer hangs, the outer close hangs, vite's allSettled hangs, finally
+    // never runs. this proves the full chokidar-style pattern resolves here.
+    it("chokidar-style close pattern resolves via fs.watch 'close' event", async () => {
+      const { ctx } = setup({
+        "/chokidar-like.js": `
+          const fs = require("node:fs");
+          fs.writeFileSync("/a.txt", "a");
+          fs.writeFileSync("/b.txt", "b");
+          fs.writeFileSync("/c.txt", "c");
+
+          // mirror chokidar: Map of path -> watcher, close returns a promise
+          // that resolves when the watcher emits 'close'.
+          const watchers = new Map();
+          for (const p of ["/a.txt", "/b.txt", "/c.txt"]) {
+            const w = fs.watch(p, () => {});
+            const closePromise = new Promise((resolve) => {
+              w.once("close", resolve);
+            });
+            watchers.set(p, { w, closePromise });
+          }
+
+          async function chokidarClose() {
+            const closers = [];
+            for (const [, entry] of watchers) {
+              entry.w.close();
+              closers.push(entry.closePromise);
+            }
+            await Promise.all(closers);
+          }
+
+          setTimeout(async () => {
+            await chokidarClose();
+            console.log("chokidar-closed");
+            process.exit(0);
+          }, 10);
+        `,
+      });
+      const t0 = performance.now();
+      const r = await executeNodeBinary("/chokidar-like.js", [], ctx);
+      const elapsed = performance.now() - t0;
+      expect(r.stdout).toContain("chokidar-closed");
+      expect(r.exitCode).toBe(0);
+      expect(elapsed).toBeLessThan(500);
+    });
+  });
+});

--- a/src/helpers/event-loop.ts
+++ b/src/helpers/event-loop.ts
@@ -1,96 +1,239 @@
-// Event loop ref-counting, mirroring Node.js/libuv semantics.
-// Process stays alive while refCount > 0 (servers, readline, child procs).
-// Supports both global mode and per-ProcessContext mode.
+// Event loop liveness tracking, same idea as libuv's HandleWrap model.
+// Each async primitive registers a typed Handle, and the process stays
+// alive as long as any Handle is refed. close() is idempotent and auto-unrefs
+// so polyfills don't have to pair every register with a matching unref
+// in their error paths.
 
-import type { ProcessContext } from "../threading/process-context";
 import { getActiveContext } from "../threading/process-context";
 
-/* ---- Global state (fallback when no ProcessContext) ---- */
+// process.exit() throws this to unwind the script. We brand it so consumers
+// can use isExitSentinel(e) instead of matching on err.message, which would
+// break if the message ever changed and could misclassify user errors that
+// happen to start with the same prefix.
 
-let _refCount = 0;
-const _drainListeners = new Set<() => void>();
+const EXIT_SENTINEL_BRAND = Symbol.for("nodepod.ProcessExitSentinel");
 
-function effectiveDrainListeners(): Set<() => void> {
-  const ctx = getActiveContext();
-  return ctx?.drainListeners ?? _drainListeners;
-}
-
-/* ---- Public API ---- */
-
-export function addDrainListener(cb: () => void): () => void {
-  const listeners = effectiveDrainListeners();
-  listeners.add(cb);
-  return () => listeners.delete(cb);
-}
-
-export function notifyDrain(): void {
-  const ctx = getActiveContext();
-  if (ctx) {
-    for (const cb of ctx.drainListeners) cb();
-  }
-  // Always notify global too (ProcessManager observers)
-  for (const cb of _drainListeners) cb();
-}
-
-export function ref(): void {
-  const ctx = getActiveContext();
-  if (ctx) {
-    ctx.refCount++;
-  } else {
-    _refCount++;
+export class ProcessExitSentinel extends Error {
+  readonly exitCode: number;
+  // structural brand, survives cross-realm throws where instanceof fails
+  readonly [EXIT_SENTINEL_BRAND] = true as const;
+  constructor(code: number) {
+    super(`Process exited with code ${code}`);
+    this.name = "ProcessExitSentinel";
+    this.exitCode = code;
   }
 }
 
-export function unref(): void {
-  const ctx = getActiveContext();
-  if (ctx) {
-    if (ctx.refCount > 0) ctx.refCount--;
-  } else {
-    if (_refCount > 0) _refCount--;
+export function isExitSentinel(e: unknown): boolean {
+  if (e instanceof ProcessExitSentinel) return true;
+  if (
+    e &&
+    typeof e === "object" &&
+    (e as { [EXIT_SENTINEL_BRAND]?: true })[EXIT_SENTINEL_BRAND] === true
+  ) {
+    return true;
   }
-  notifyDrain();
+  return false;
 }
 
-export function getRefCount(): number {
-  const ctx = getActiveContext();
-  return ctx ? ctx.refCount : _refCount;
+// handle types, roughly lines up with libuv resource names plus a few node extras
+
+export type HandleType =
+  | "Timeout"
+  | "Immediate"
+  | "Interval"
+  | "FetchRequest"
+  | "DynamicImport"
+  | "TCPSocketWrap"
+  | "TCPServerWrap"
+  | "UDPWrap"
+  | "PipeWrap"
+  | "IPCChannel"
+  | "TLSWrap"
+  | "HTTP2Session"
+  | "HTTPServer"
+  | "FSReqCallback"
+  | "FSWatcher"
+  | "StatWatcher"
+  | "WebSocket"
+  | "MessagePort"
+  | "BroadcastChannel"
+  | "Worker"
+  | "ChildProcess"
+  | "TTYWrap"
+  | "ReadlineInterface"
+  | "EsbuildOp"
+  | "WASMWork";
+
+export interface Handle {
+  readonly type: HandleType;
+  readonly registry: HandleRegistry;
+  readonly refed: boolean;
+  readonly closed: boolean;
+  ref(): this;
+  unref(): this;
+  close(): void;
 }
 
-export function setRefCount(n: number): void {
-  const ctx = getActiveContext();
-  if (ctx) {
-    ctx.refCount = n;
-  } else {
-    _refCount = n;
+export interface HandleRegistry {
+  register(type: HandleType, opts?: { refed?: boolean }): Handle;
+  activeRefedCount(): number;
+  list(): ReadonlyArray<Handle>;
+  groupedByType(): Record<string, number>;
+  /** Fresh promise each drain cycle. Resolves on refed-count 1 to 0. */
+  drainPromise(): Promise<void>;
+  onDrain(cb: () => void): () => void;
+  /** Awaits each beforeExit handler sequentially. */
+  emitBeforeExit(code: number): Promise<void>;
+  onBeforeExit(cb: (code: number) => void | Promise<void>): () => void;
+  closeAll(): void;
+}
+
+class HandleImpl implements Handle {
+  readonly type: HandleType;
+  readonly registry: RegistryImpl;
+  refed: boolean;
+  closed = false;
+  constructor(registry: RegistryImpl, type: HandleType, refed: boolean) {
+    this.registry = registry;
+    this.type = type;
+    this.refed = refed;
+  }
+  ref(): this {
+    if (this.closed || this.refed) return this;
+    this.refed = true;
+    this.registry._incRefed();
+    return this;
+  }
+  unref(): this {
+    if (this.closed || !this.refed) return this;
+    this.refed = false;
+    this.registry._decRefed();
+    return this;
+  }
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    if (this.refed) {
+      this.refed = false;
+      this.registry._decRefed();
+    }
+    this.registry._remove(this);
   }
 }
 
-export function resetRefCount(): void {
-  const ctx = getActiveContext();
-  if (ctx) {
-    ctx.refCount = 0;
-  } else {
-    _refCount = 0;
+class RegistryImpl implements HandleRegistry {
+  private _handles = new Set<HandleImpl>();
+  private _refedCount = 0;
+  private _drainCbs = new Set<() => void>();
+  private _beforeExitCbs: Array<(code: number) => void | Promise<void>> = [];
+  private _drainPromise: Promise<void> | null = null;
+  private _drainResolve: (() => void) | null = null;
+
+  register(type: HandleType, opts?: { refed?: boolean }): Handle {
+    const refed = opts?.refed !== false;
+    const h = new HandleImpl(this, type, refed);
+    this._handles.add(h);
+    if (refed) this._refedCount++;
+    return h;
+  }
+
+  activeRefedCount(): number {
+    return this._refedCount;
+  }
+
+  list(): ReadonlyArray<Handle> {
+    return Array.from(this._handles);
+  }
+
+  groupedByType(): Record<string, number> {
+    const out: Record<string, number> = {};
+    for (const h of this._handles) {
+      if (!h.refed) continue;
+      out[h.type] = (out[h.type] ?? 0) + 1;
+    }
+    return out;
+  }
+
+  drainPromise(): Promise<void> {
+    if (this._refedCount === 0) return Promise.resolve();
+    if (this._drainPromise) return this._drainPromise;
+    this._drainPromise = new Promise<void>((resolve) => {
+      this._drainResolve = resolve;
+    });
+    return this._drainPromise;
+  }
+
+  onDrain(cb: () => void): () => void {
+    this._drainCbs.add(cb);
+    return () => this._drainCbs.delete(cb);
+  }
+
+  async emitBeforeExit(code: number): Promise<void> {
+    // snapshot so handlers that register more listeners don't fire this cycle
+    const snapshot = this._beforeExitCbs.slice();
+    for (const cb of snapshot) {
+      try {
+        await cb(code);
+      } catch (e) {
+        // process.exit() from a handler throws the sentinel, re-throw so the
+        // wait loop sees it. other errors are swallowed, same as node.
+        if (isExitSentinel(e)) throw e;
+      }
+    }
+  }
+
+  onBeforeExit(cb: (code: number) => void | Promise<void>): () => void {
+    this._beforeExitCbs.push(cb);
+    return () => {
+      const i = this._beforeExitCbs.indexOf(cb);
+      if (i >= 0) this._beforeExitCbs.splice(i, 1);
+    };
+  }
+
+  closeAll(): void {
+    // snapshot first, close() mutates the set
+    for (const h of Array.from(this._handles)) h.close();
+  }
+
+  _incRefed(): void {
+    this._refedCount++;
+  }
+
+  _decRefed(): void {
+    if (this._refedCount > 0) this._refedCount--;
+    if (this._refedCount === 0) {
+      const resolve = this._drainResolve;
+      this._drainPromise = null;
+      this._drainResolve = null;
+      if (resolve) resolve();
+      for (const cb of this._drainCbs) {
+        try {
+          cb();
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+  }
+
+  _remove(h: HandleImpl): void {
+    this._handles.delete(h);
   }
 }
 
-/* ---- Context-specific API ---- */
+// global registry is the fallback when no ProcessContext is active
+const _globalRegistry = new RegistryImpl();
 
-export function refCtx(ctx: ProcessContext): void {
-  ctx.refCount++;
+export function getRegistry(): HandleRegistry {
+  const ctx = getActiveContext();
+  return (ctx?.handles as HandleRegistry | undefined) ?? _globalRegistry;
 }
 
-export function unrefCtx(ctx: ProcessContext): void {
-  if (ctx.refCount > 0) ctx.refCount--;
-  for (const cb of ctx.drainListeners) cb();
-  for (const cb of _drainListeners) cb();
+export function getGlobalRegistry(): HandleRegistry {
+  return _globalRegistry;
 }
 
-export function getRefCountCtx(ctx: ProcessContext): number {
-  return ctx.refCount;
-}
-
-export function addDrainListenerCtx(ctx: ProcessContext, cb: () => void): () => void {
-  ctx.drainListeners.add(cb);
-  return () => ctx.drainListeners.delete(cb);
+export function createHandleRegistry(): HandleRegistry {
+  return new RegistryImpl();
 }

--- a/src/helpers/napi-wasm-worker.ts
+++ b/src/helpers/napi-wasm-worker.ts
@@ -14,7 +14,7 @@
 
 import type { MemoryVolume } from "../memory-volume";
 import { EventEmitter } from "../polyfills/events";
-import { ref as eventLoopRef, unref as eventLoopUnref } from "./event-loop";
+import { getRegistry, type Handle } from "./event-loop";
 
 /**
  * true if scriptPath is a wasi-worker script in a node_modules package that
@@ -223,18 +223,15 @@ export function createNapiWorkerFactory(
       onMessage: (data: unknown) => self.emit("message", data),
       onError: (err: Error) => self.emit("error", err),
       onExit: (code: number) => {
-        if (self._isReffed) {
-          self._isReffed = false;
-          eventLoopUnref();
-        }
+        (self._elHandle as Handle | null)?.close();
+        self._elHandle = null;
         self._terminated = true;
         self.emit("exit", code);
       },
     });
 
     this._handle = handle;
-    this._isReffed = true;
-    eventLoopRef();
+    this._elHandle = getRegistry().register("Worker");
     queueMicrotask(() => {
       if (!self._terminated) self.emit("online");
     });
@@ -261,7 +258,7 @@ function createRealWebWorker(
   self.resourceLimits = {};
   self._handle = null;
   self._terminated = false;
-  self._isReffed = false;
+  self._elHandle = null;
 
   let bundleSource = bundleCache.get(scriptPath);
   if (!bundleSource) {
@@ -317,6 +314,15 @@ function createRealWebWorker(
 
   realWorker.onerror = (e: ErrorEvent) => {
     self.emit("error", new Error(e.message || "Worker error"));
+    // web workers don't emit exit, so on an unhandled error close the
+    // handle ourselves and fake exit code 1 to match node. otherwise a
+    // crashed wasi worker leaks the loop ref forever.
+    if (!self._terminated) {
+      (self._elHandle as Handle | null)?.close();
+      self._elHandle = null;
+      self._terminated = true;
+      try { self.emit("exit", 1); } catch { /* ignore */ }
+    }
   };
 
   self._realWorker = realWorker;
@@ -327,33 +333,24 @@ function createRealWebWorker(
   };
   self.terminate = () => {
     if (!self._terminated) {
-      if (self._isReffed) {
-        self._isReffed = false;
-        eventLoopUnref();
-      }
+      (self._elHandle as Handle | null)?.close();
+      self._elHandle = null;
       self._terminated = true;
       realWorker.terminate();
     }
     return Promise.resolve(0);
   };
   self.ref = () => {
-    if (!self._isReffed && !self._terminated) {
-      self._isReffed = true;
-      eventLoopRef();
-    }
+    if (!self._terminated) (self._elHandle as Handle | null)?.ref();
     return self;
   };
   self.unref = () => {
-    if (self._isReffed) {
-      self._isReffed = false;
-      eventLoopUnref();
-    }
+    (self._elHandle as Handle | null)?.unref();
     return self;
   };
 
   // start reffed like Node.js does
-  self._isReffed = true;
-  eventLoopRef();
+  self._elHandle = getRegistry().register("Worker");
 
   queueMicrotask(() => {
     if (!self._terminated) self.emit("online");

--- a/src/memory-volume.ts
+++ b/src/memory-volume.ts
@@ -69,13 +69,19 @@ export interface FileWatchHandle {
 class FSWatcher implements FileWatchHandle {
   private _listeners = new Map<string, Array<(...args: unknown[]) => void>>();
   private _closeFn: (() => void) | null = null;
+  private _closed = false;
 
   constructor(closeFn: () => void) {
     this._closeFn = closeFn;
   }
 
   close(): void {
+    if (this._closed) return;
+    this._closed = true;
     if (this._closeFn) { this._closeFn(); this._closeFn = null; }
+    // emit 'close' before clearing listeners so subscribers actually get it.
+    // chokidar and friends wait on this event to know the handle's released.
+    this.emit("close");
     this._listeners.clear();
   }
   ref(): this { return this; }

--- a/src/polyfills/child_process.ts
+++ b/src/polyfills/child_process.ts
@@ -10,8 +10,13 @@ import type { MemoryVolume } from "../memory-volume";
 import { ScriptEngine } from "../script-engine";
 import type { PackageManifest } from "../types/manifest";
 import { resetActiveInterfaceCount } from "./readline";
-import { ref, unref, getRefCount, resetRefCount, addDrainListener } from "../helpers/event-loop";
-import { getActiveContext, setActiveContext } from "../threading/process-context";
+import {
+  getRegistry,
+  isExitSentinel,
+  ProcessExitSentinel,
+  type Handle,
+} from "../helpers/event-loop";
+import { createProcessContext, getActiveContext, setActiveContext } from "../threading/process-context";
 import type { ProcessContext } from "../threading/process-context";
 import type { PmDeps, PkgManager } from "../shell/commands/pm-types";
 import { createNpmCommand } from "../shell/commands/npm";
@@ -21,12 +26,18 @@ import { createBunCommand, createBunxCommand } from "../shell/commands/bun";
 import { createNodeCommand, createNpxCommand } from "../shell/commands/node";
 import { createGitCommand } from "../shell/commands/git";
 import { format as utilFormat } from "./util";
-import { VERSIONS, NPM_REGISTRY_URL_SLASH, TIMEOUTS, DEFAULT_ENV, MOCK_PID } from "../constants/config";
+import { VERSIONS, NPM_REGISTRY_URL_SLASH, DEFAULT_ENV, MOCK_PID } from "../constants/config";
 import { closeAllServers, getAllServers } from "./http";
 import type { SyncChannelWorker } from "../threading/sync-channel";
 
 let _shell: NodepodShell | null = null;
 let _vol: MemoryVolume | null = null;
+
+// grab the native setTimeout before script-engine patches it. we use this
+// to yield to the host task queue without creating a tracked Handle that
+// would bump the refed count.
+const _nativeSetTimeout: typeof globalThis.setTimeout =
+  globalThis.setTimeout.bind(globalThis);
 
 let _syncChannel: SyncChannelWorker | null = null;
 
@@ -356,7 +367,7 @@ function evalNodeCode(code: string, ctx: ShellContext): ShellResult {
   try {
     sandbox.execute(code, "/<eval>.js");
   } catch (e) {
-    if (e instanceof Error && e.message.startsWith("Process exited with code"))
+    if (isExitSentinel(e))
       return { stdout: out, stderr: err, exitCode: 0 };
     err += `Error: ${e instanceof Error ? e.message : String(e)}\n`;
     return { stdout: out, stderr: err, exitCode: 1 };
@@ -1084,6 +1095,37 @@ export async function executeNodeBinary(
   // ScriptEngine's module wrapper overwrites globalThis.process -- save and restore
   const savedProcess = (globalThis as any).process;
 
+  // isolate this script's HandleRegistry from the outer (vitest/host) process.
+  // without this, any setTimeout the host schedules ends up in the same
+  // _globalRegistry the wait loop inspects, so outer timers count as live
+  // handles and we block forever waiting for a drain that won't come. still
+  // inherit streaming config so stdout/stderr/resize keep working.
+  const prevCtx = getActiveContext();
+  const localCtx = createProcessContext({
+    volume: _vol,
+    cwd: ctx.cwd,
+    env: ctx.env,
+  });
+  localCtx.stdoutSink = prevCtx?.stdoutSink ?? _stdoutSink;
+  localCtx.stderrSink = prevCtx?.stderrSink ?? _stderrSink;
+  localCtx.liveStdin = prevCtx?.liveStdin ?? _liveStdin;
+  localCtx.termCols = prevCtx?.termCols ?? _termCols;
+  localCtx.termRows = prevCtx?.termRows ?? _termRows;
+  // Propagate halt/abort from parent context or module signal
+  if (prevCtx && prevCtx.abortController.signal.aborted) {
+    localCtx.abortController.abort();
+  } else if (_haltSignal?.aborted) {
+    localCtx.abortController.abort();
+  } else if (_haltSignal) {
+    _haltSignal.addEventListener(
+      "abort",
+      () => localCtx.abortController.abort(),
+      { once: true },
+    );
+  }
+  setActiveContext(localCtx);
+
+  try {
   const sandbox = new ScriptEngine(_vol, {
     cwd: ctx.cwd,
     env: ctx.env,
@@ -1091,7 +1133,11 @@ export async function executeNodeBinary(
       // filter out process.exit sentinel errors logged by library code
       if (cArgs.length === 1) {
         const a = cArgs[0];
-        if (a instanceof Error && a.message.startsWith("Process exited with code")) return;
+        if (isExitSentinel(a)) return;
+        // a library may have stringified the sentinel before logging
+        // (e.g. console.error(String(err))). message format is stable
+        // so matching on toString is fine. worst case we swallow a user
+        // log line that happens to start with the same prefix.
         if (typeof a === "string" && a.startsWith("Error: Process exited with code")) return;
       }
       // error/warn → stderr, everything else → stdout
@@ -1110,21 +1156,28 @@ export async function executeNodeBinary(
     if (_shell) _shell.setCwd(dir);
   };
 
+  // resolves when proc.exit() is called. the wait loop races this against
+  // drainPromise/haltPromise so an exit() from an event handler (e.g.
+  // vite's `q` shortcut) wakes the loop right away instead of waiting
+  // for the next handle drain.
+  let exitResolve!: () => void;
+  const exitPromise = new Promise<void>((r) => { exitResolve = r; });
+
   proc.exit = ((c = 0) => {
     // suppress exit when dev servers are active (SES/error handlers call exit(1) but we want to keep serving)
     if (getAllServers().size > 0 && c !== 0) {
-      // process.exit suppressed — servers still active
       return;
     }
     if (!didExit) {
       didExit = true;
       code = c;
       proc.emit("exit", c);
+      exitResolve();
     }
-    // Always throw to halt execution — mirrors real Node.js process.exit()
-    // which terminates immediately. The TLA .catch() and try/catch both
-    // handle "Process exited with code" errors.
-    throw new Error(`Process exited with code ${c}`);
+    // always throw to halt. matches real node process.exit() which
+    // terminates immediately. TLA .catch and try/catch use isExitSentinel()
+    // to detect and suppress this unwind.
+    throw new ProcessExitSentinel(c);
   }) as (c?: number) => never;
 
   proc.argv = ["node", resolved, ...args];
@@ -1183,31 +1236,32 @@ export async function executeNodeBinary(
     _activeProcs.add(proc as any);
   }
 
-  // for forked children: ref() to simulate the IPC channel handle.
-  // real Node.js keeps the IPC channel ref'd until process.disconnect().
-  // we hold a ref for the entire fork lifetime, released on disconnect or exit.
+  // forked children keep an IPCChannel handle for the whole fork lifetime,
+  // released on disconnect or exit. "IPCChannel" matches what real node
+  // reports from process.getActiveResourcesInfo() for fork IPC channels.
   const isFork = !!opts?.isFork;
+  let ipcHandle: Handle | null = null;
   if (isFork) {
-    ref();
-    // disconnect → unref (mirrors Node.js IPC channel.unref())
+    ipcHandle = getRegistry().register("IPCChannel");
     const origDisconnect = proc.disconnect;
     proc.disconnect = (() => {
       origDisconnect?.call(proc);
-      unref();
+      ipcHandle?.close();
+      ipcHandle = null;
     }) as () => void;
   }
 
   let scriptError: Error | null = null;
   let tlaSettled = false;
+  // wake the loop on TLA settle so we don't have to poll
+  let tlaResolve!: () => void;
+  const tlaDonePromise = new Promise<void>((r) => { tlaResolve = r; });
 
   try {
     const tlaPromise = sandbox.runFileTLA(resolved);
     tlaPromise
       .catch((e) => {
-        if (
-          e instanceof Error &&
-          e.message.startsWith("Process exited with code")
-        ) {
+        if (isExitSentinel(e)) {
           return;
         }
         const msg = formatThrown(e);
@@ -1219,13 +1273,11 @@ export async function executeNodeBinary(
       })
       .finally(() => {
         tlaSettled = true;
+        tlaResolve();
       });
   } catch (e) {
-    if (
-      e instanceof Error &&
-      e.message.startsWith("Process exited with code")
-    ) {
-      // process.exit() — handled by didExit flag
+    if (isExitSentinel(e)) {
+      // handled by didExit flag
     } else {
       const msg = formatThrown(e);
       scriptError = e instanceof Error ? e : new Error(msg);
@@ -1253,23 +1305,80 @@ export async function executeNodeBinary(
     return { stdout: out, stderr: err, exitCode: code };
   }
 
-  // yield one tick so microtasks settle
-  await new Promise((r) => setTimeout(r, 0));
+  // yield once before the first wait-loop decision. crossing a macrotask
+  // boundary drains the whole microtask queue, which lets deep await chains
+  // (common in create-qwik style CLIs: await a; await b; await c; finally
+  // setTimeout) reach their Handle-registering point before we check
+  // activeRefedCount.
+  await new Promise<void>((r) => _nativeSetTimeout(r, 0));
 
-  // keep the process alive while TLA hasn't settled, ref handles exist,
-  // or HTTP servers are registered. process.exit() and Ctrl+C break immediately.
-
+  // node exit rule, libuv parity: the loop is alive iff TLA is pending or
+  // activeRefedCount > 0. no timeouts, no output heuristics. every async
+  // primitive refs its own Handle and we trust the counter.
+  const registry = getRegistry();
   const shouldStayAlive = (): boolean => {
     if (!tlaSettled) return true;
-    if (getRefCount() > 0) return true;
-    if (getAllServers().size > 0) return true;
-    return false;
+    return registry.activeRefedCount() > 0;
   };
 
-  // fast path: nothing keeping the process alive
+  // resolve the tentative exit code node-style: explicit process.exit(c)
+  // wins, otherwise process.exitCode (user-settable), otherwise 0.
+  const currentCode = (): number => {
+    if (didExit) return code;
+    const ec = (proc as any).exitCode;
+    return typeof ec === "number" ? ec : 0;
+  };
+
+  // beforeExit state carries across fast-path and wait-loop exits. reset to
+  // false whenever activeRefedCount > 0 again so each drain-to-zero cycle
+  // can fire it (matches node's SpinEventLoop).
+  let beforeExitEmitted = false;
+  const emitBeforeExitOnce = async () => {
+    if (beforeExitEmitted) return;
+    beforeExitEmitted = true;
+    const beforeCode = currentCode();
+    // proc.emit is sync. if a handler calls process.exit() it throws the
+    // sentinel, let didExit propagate and bail without emitting further.
+    try {
+      proc.emit("beforeExit", beforeCode);
+    } catch (e) {
+      if (isExitSentinel(e)) {
+        return;
+      }
+      // other handler errors: swallow (matches node's exit-time semantics)
+    }
+    try {
+      await registry.emitBeforeExit(beforeCode);
+    } catch (e) {
+      if (isExitSentinel(e)) {
+        return;
+      }
+    }
+    // full drain via a native setTimeout(0). queueMicrotask only covers
+    // one microtask step, but await chains keep queueing more microtasks.
+    // setTimeout(0) crosses a macrotask boundary and forces V8 to flush
+    // every pending microtask before resuming us. using the NATIVE
+    // setTimeout (captured before patching) means this yield doesn't
+    // register a tracked Handle that would inflate the refed count.
+    await new Promise<void>((r) => _nativeSetTimeout(r, 0));
+  };
+
+  // fast path: script finished synchronously with nothing scheduled.
+  // still emit beforeExit; handlers may schedule more work and if they
+  // do we fall through into the real wait loop below.
   if (!myHaltSignal && !shouldStayAlive()) {
-    cleanup();
-    return { stdout: out, stderr: err, exitCode: 0 };
+    if (!didExit) await emitBeforeExitOnce();
+    if (!didExit && !shouldStayAlive()) {
+      const finalCode = currentCode();
+      // emit 'exit' on natural drain. node fires it once, whether the
+      // loop drained naturally or process.exit() was called. the exit()
+      // path already emitted it from the proc.exit override.
+      try { proc.emit("exit", finalCode); } catch { /* ignore */ }
+      cleanup();
+      return { stdout: out, stderr: err, exitCode: finalCode };
+    }
+    // a beforeExit handler revived the loop, fall through to the wait loop
+    if (shouldStayAlive()) beforeExitEmitted = false;
   }
 
   // avoid duplicate output when same error fires as both 'error' and 'unhandledrejection'
@@ -1278,22 +1387,18 @@ export async function executeNodeBinary(
   const rejHandler = (ev: PromiseRejectionEvent) => {
     ev.preventDefault();
     const r = ev.reason;
-    if (
-      r instanceof Error &&
-      r.message.startsWith("Process exited with code")
-    ) {
+    if (isExitSentinel(r)) {
       return;
     }
-    // mark as handled to prevent errHandler double-logging
+    // mark as handled so errHandler doesn't double-log
     if (r != null && typeof r === "object") handledErrors.add(r);
-    // emit 'unhandledRejection' on process -- if a handler exists, it handles it
     try {
       const hasHandler = proc.listenerCount
         ? proc.listenerCount("unhandledRejection") > 0
         : false;
       proc.emit("unhandledRejection", r, ev.promise);
-      if (hasHandler) return; // Handler dealt with it — don't log
-    } catch { /* ignore handler errors */ }
+      if (hasHandler) return;
+    } catch { /* ignore */ }
     const rejMsg = r instanceof Error
       ? `Unhandled rejection: ${r.message}\n${r.stack ?? ""}\n`
       : `Unhandled rejection: ${String(r)}\n`;
@@ -1302,18 +1407,21 @@ export async function executeNodeBinary(
   const errHandler = (ev: ErrorEvent) => {
     ev.preventDefault();
     const e = ev.error ?? new Error(ev.message || "Unknown error");
-    // skip if already handled by rejHandler (same error fires on both global events)
+    if (isExitSentinel(e)) {
+      return;
+    }
+    // same error may fire on both unhandledrejection and error, dedupe.
     if (e != null && typeof e === "object" && handledErrors.has(e)) return;
     if (e != null && typeof e === "object") handledErrors.add(e);
-    // emit 'uncaughtException' -- frameworks like webpack register handlers for graceful recovery
+    // webpack and friends register uncaughtException handlers for graceful recovery
     try {
       const hasUncaught = proc.listenerCount
         ? proc.listenerCount("uncaughtException") > 0
         : false;
       proc.emit("uncaughtException", e);
-      if (hasUncaught) return; // Handler dealt with it — don't log or crash
-    } catch { /* handler threw — fall through to default logging */ }
-    // if there's an unhandledRejection listener, it'll handle this -- don't double-log
+      if (hasUncaught) return;
+    } catch { /* ignore */ }
+    // if there's an unhandledRejection listener, it'll handle this, don't double-log
     try {
       const hasRej = proc.listenerCount
         ? proc.listenerCount("unhandledRejection") > 0
@@ -1325,8 +1433,12 @@ export async function executeNodeBinary(
       : `Uncaught: ${String(e)}\n`;
     pushErr(msg);
   };
-  globalThis.addEventListener("unhandledrejection", rejHandler);
-  globalThis.addEventListener("error", errHandler);
+  // browser and Worker globalThis has addEventListener, node-test doesn't.
+  const hasGlobalEvents = typeof (globalThis as any).addEventListener === "function";
+  if (hasGlobalEvents) {
+    (globalThis as any).addEventListener("unhandledrejection", rejHandler);
+    (globalThis as any).addEventListener("error", errHandler);
+  }
 
   try {
     // resolves when Ctrl+C / signal fires
@@ -1337,91 +1449,84 @@ export async function executeNodeBinary(
         })
       : null;
 
-    // give async startup code time to register handles before deciding the process is done
-    let consecutiveEmpty = 0;
-    let everNonEmpty = false;
+    // event-driven wait loop. wake sources:
+    //   drainPromise: activeRefedCount transitions to 0
+    //   tlaDonePromise: top-level-await settles
+    //   haltPromise: Ctrl+C / SIGINT
+    //   exitPromise: process.exit() from anywhere (including async handlers
+    //     like vite's `q` shortcut). without this, an exit() from a handler
+    //     that runs while we're awaiting drainPromise wouldn't wake us until
+    //     drain happens, which might never happen if readline/stdin keep
+    //     the loop alive.
+    // on any wake, check if we should still be alive. if not, emit beforeExit,
+    // let handlers schedule more work, re-check, exit if truly drained.
 
-    while (!didExit) {
-      if (myHaltSignal?.aborted) {
-        break;
+    while (!didExit && !myHaltSignal?.aborted) {
+      // TLA still pending, wait for it (or drain/halt/exit).
+      if (!tlaSettled) {
+        const racers: Promise<unknown>[] = [
+          tlaDonePromise,
+          registry.drainPromise(),
+          exitPromise,
+        ];
+        if (haltPromise) racers.push(haltPromise);
+        await Promise.race(racers);
+        continue;
       }
 
-      // wake on drain notification or periodic tick
-      let wakeResolve!: () => void;
-      const wakePromise = new Promise<void>((r) => { wakeResolve = r; });
-      const removeDrain = addDrainListener(wakeResolve);
-
-      const tickMs = (!everNonEmpty && myHaltSignal && !out && !err)
-        ? TIMEOUTS.WAIT_LOOP_TICK
-        : 50;
-      const racers: Promise<unknown>[] = [
-        wakePromise,
-        new Promise<void>((r) => setTimeout(r, tickMs)),
-      ];
-      if (haltPromise) racers.push(haltPromise);
-
-      await Promise.race(racers);
-      removeDrain();
-
-      if (myHaltSignal?.aborted) {
-        break;
-      }
-      if (didExit) {
-        break;
-      }
-
-      if (!shouldStayAlive()) {
-        // yield one microtask turn for async transitions (e.g. @clack closing/reopening readline)
-        await new Promise<void>((r) => queueMicrotask(r));
-        if (didExit || myHaltSignal?.aborted) break;
-        if (shouldStayAlive()) {
-          everNonEmpty = true;
-          consecutiveEmpty = 0;
-          continue;
-        }
-
-        consecutiveEmpty++;
-
-        if (myHaltSignal) {
-          // terminal mode: tiered timeout -- no output yet (10s), had refs before (5s), output but no refs (2s)
-          if (!everNonEmpty && !out && !err) {
-            if (consecutiveEmpty >= 50) {
-              break;
-            }
-          } else if (!everNonEmpty) {
-            if (consecutiveEmpty >= Math.ceil(2_000 / tickMs)) {
-              break;
-            }
-          } else {
-            if (consecutiveEmpty >= 100) {
-              break;
-            }
+      // TLA has settled. Check live handles.
+      if (registry.activeRefedCount() === 0) {
+        if (!beforeExitEmitted) {
+          await emitBeforeExitOnce();
+          if (didExit || myHaltSignal?.aborted) break;
+          if (registry.activeRefedCount() > 0) {
+            // a beforeExit handler revived us, reset for the next drain
+            beforeExitEmitted = false;
+            continue;
           }
-        } else {
-          break; // Non-terminal: exit immediately when empty.
         }
-      } else {
-        consecutiveEmpty = 0;
-        everNonEmpty = true;
+        break;
       }
+
+      // something is refed, wait for drain/halt/exit.
+      const racers: Promise<unknown>[] = [registry.drainPromise(), exitPromise];
+      if (haltPromise) racers.push(haltPromise);
+      await Promise.race(racers);
+
+      // if anything was scheduled while draining, allow beforeExit to fire
+      // again on the next drain-to-zero cycle
+      if (registry.activeRefedCount() > 0) beforeExitEmitted = false;
     }
 
-    return { stdout: out, stderr: err, exitCode: didExit ? code : 0 };
+    const finalCode = currentCode();
+    // emit 'exit' on natural drain. process.exit() path already emitted
+    // it from proc.exit, so skip if didExit is true.
+    if (!didExit) {
+      try { proc.emit("exit", finalCode); } catch { /* ignore */ }
+    }
+    return { stdout: out, stderr: err, exitCode: finalCode };
   } finally {
     cleanup();
-    // defuse proc.exit so floating Promises don't throw unhandled rejections
+    // defuse proc.exit so floating promises don't throw unhandled rejections
     proc.exit = (() => {}) as unknown as (c?: number) => never;
-    globalThis.removeEventListener("unhandledrejection", rejHandler);
-    globalThis.removeEventListener("error", errHandler);
-    // restore _liveStdin for the parent's stdin relay
+    if (hasGlobalEvents) {
+      (globalThis as any).removeEventListener("unhandledrejection", rejHandler);
+      (globalThis as any).removeEventListener("error", errHandler);
+    }
     _liveStdin = prevLiveStdin;
     const ctxRestore = getActiveContext();
     if (ctxRestore) ctxRestore.liveStdin = prevLiveStdin;
     _activeProcs.delete(proc as any);
-    // full reset
     closeAllServers();
-    resetRefCount();
+    getRegistry().closeAll();
     resetActiveInterfaceCount();
+  }
+  } finally {
+    // restore outer process context. must happen AFTER the inner finally
+    // has closed this script's registry and restored streaming callbacks.
+    // reached from every exit path including early returns and thrown
+    // errors from ScriptEngine construction.
+    setActiveContext(prevCtx);
   }
 }
 
@@ -1943,6 +2048,29 @@ function handleSyncCommand(cmd: string, opts?: RunOptions): string | null {
   return null;
 }
 
+// stdio normalizer. accepts:
+//   'pipe'|'inherit'|'ignore'     expanded to [same, same, same]
+//   ['pipe','inherit','ignore']   kept as-is, padded to 3
+//   undefined                     'pipe' (node's default for spawn)
+function normalizeStdio(
+  stdio: SpawnConfig["stdio"] | undefined,
+): ["pipe" | "inherit" | "ignore", "pipe" | "inherit" | "ignore", "pipe" | "inherit" | "ignore"] {
+  const norm = (v: unknown): "pipe" | "inherit" | "ignore" => {
+    if (v === "inherit" || v === "ignore" || v === "pipe") return v;
+    // streams, fds, null/undefined: treat as pipe
+    return "pipe";
+  };
+  if (stdio == null) return ["pipe", "pipe", "pipe"];
+  if (typeof stdio === "string") {
+    const v = norm(stdio);
+    return [v, v, v];
+  }
+  if (Array.isArray(stdio)) {
+    return [norm(stdio[0]), norm(stdio[1]), norm(stdio[2])];
+  }
+  return ["pipe", "pipe", "pipe"];
+}
+
 export function spawn(
   command: string,
   argsOrOpts?: string[] | SpawnConfig,
@@ -1956,40 +2084,59 @@ export function spawn(
   } else if (argsOrOpts) cfg = argsOrOpts;
 
   const child = new ShellProcess();
+  // normalize stdio, node parity: 'pipe' default, 'inherit' to share parent
+  // streams, 'ignore' to drop. current spawn protocol only carries one
+  // top-level "pipe"|"inherit" so we pass "inherit" when stdin is inherit,
+  // else "pipe". stdout/stderr inherit works anyway because the streaming
+  // onStdout/onStderr callbacks route through getStdoutSink/getStderrSink.
+  const stdioArr = normalizeStdio(cfg.stdio);
+  const stdinInherit = stdioArr[0] === "inherit";
+  const stdoutInherit = stdioArr[1] === "inherit";
+  const stderrInherit = stdioArr[2] === "inherit";
 
-  // spawn() gets a dedicated worker (streaming output, long-lived processes).
-  // exec() runs inline since it collects all output at the end.
+  // spawn gets a dedicated worker (streaming output, long-lived). exec runs
+  // inline since it collects all output at the end.
   if (_spawnChildFn) {
     const cwd = cfg.cwd ?? getShellCwd();
     const env = (cfg.env as Record<string, string>) ?? {};
     const fullCmd = spawnArgs.length ? `${command} ${spawnArgs.join(" ")}` : command;
 
-    // keep parent alive while child is running
-    ref();
+    // keep parent alive while child is running. stash the Handle on the
+    // ShellProcess so its .ref()/.unref() can forward to it.
+    const childHandle = getRegistry().register("ChildProcess");
+    (child as any)._elHandle = childHandle;
 
-    // Track whether streaming callbacks fire (they don't for builtins like ls)
+    // builtins like ls don't stream, so track whether callbacks actually fired
     let stdoutStreamed = false;
     let stderrStreamed = false;
 
     _spawnChildFn(command, spawnArgs, {
       cwd,
       env,
-      stdio: "pipe",
+      stdio: stdinInherit ? "inherit" : "pipe",
       onStdout: (data: string) => {
         stdoutStreamed = true;
-        child.stdout?.push(Buffer.from(data));
-        // also route through parent's stdout sink for terminal output
-        const sink = getStdoutSink();
-        if (sink) sink(data);
+        // pipe: buffer for parent to read via child.stdout.on('data')
+        // ignore: drop entirely
+        if (stdioArr[1] === "pipe") child.stdout?.push(Buffer.from(data));
+        // inherit: also route through parent's stdout sink (terminal).
+        // we always route to the terminal sink for compatibility, this is
+        // what pre-stdio-normalization behavior did.
+        if (stdoutInherit) {
+          const sink = getStdoutSink();
+          if (sink) sink(data);
+        }
       },
       onStderr: (data: string) => {
         stderrStreamed = true;
-        child.stderr?.push(Buffer.from(data));
-        const sink = getStderrSink();
-        if (sink) sink(data);
+        if (stdioArr[2] === "pipe") child.stderr?.push(Buffer.from(data));
+        if (stderrInherit) {
+          const sink = getStderrSink();
+          if (sink) sink(data);
+        }
       },
     }).then(({ exitCode, stdout, stderr }) => {
-      unref(); // Child done — release event loop hold
+      childHandle.close();
       // For commands that don't stream (builtins), push the buffered output
       if (!stdoutStreamed && stdout) child.stdout?.push(Buffer.from(stdout));
       if (!stderrStreamed && stderr) child.stderr?.push(Buffer.from(stderr));
@@ -1999,7 +2146,7 @@ export function spawn(
       child.emit("close", exitCode, null);
       child.emit("exit", exitCode, null);
     }).catch((e) => {
-      unref(); // Child done — release event loop hold
+      childHandle.close();
       child.emit("error", e instanceof Error ? e : new Error(String(e)));
     });
   } else if (_shell) {
@@ -2086,6 +2233,10 @@ export function spawnSync(
   const slot = _syncChannel.allocateSlot();
   const cwd = cfg.cwd ?? (globalThis as any).process?.cwd?.() ?? "/";
   const env = (cfg.env as Record<string, string>) ?? {};
+  // carry stdio to the main thread so it knows whether terminal stdin should
+  // be forwarded to the child (inherit) vs ignored (pipe). see the spawn-sync
+  // handler in process-manager.ts.
+  const stdioArr = normalizeStdio(cfg.stdio);
 
   (self as any).postMessage({
     type: "spawn-sync",
@@ -2096,6 +2247,7 @@ export function spawnSync(
     env,
     syncSlot: slot,
     shellCommand: full,
+    stdio: stdioArr,
   });
 
   // blocks until main thread spawns child and child completes
@@ -2195,8 +2347,10 @@ export function fork(
     return child;
   }
 
-  // keep parent alive while forked child is running
-  ref();
+  // keep parent alive while the forked child runs. stash on ShellProcess
+  // so .ref()/.unref() forward to it.
+  const childHandle = getRegistry().register("ChildProcess");
+  (child as any)._elHandle = childHandle;
   const handle = _forkChildFn(resolved, args, {
     cwd,
     env,
@@ -2215,7 +2369,7 @@ export function fork(
       child.emit("message", data);
     },
     onExit: (exitCode: number) => {
-      unref(); // Child done — release event loop hold
+      childHandle.close();
       child.exitCode = exitCode;
       child.connected = false;
       child.emit("exit", exitCode, null);
@@ -2305,10 +2459,14 @@ ShellProcess.prototype.send = function send(this: any, msg: unknown, cb?: (e: Er
 };
 
 ShellProcess.prototype.ref = function ref(this: any): any {
+  const h = this._elHandle as Handle | undefined;
+  if (h) h.ref();
   return this;
 };
 
 ShellProcess.prototype.unref = function unref(this: any): any {
+  const h = this._elHandle as Handle | undefined;
+  if (h) h.unref();
   return this;
 };
 

--- a/src/polyfills/dgram.ts
+++ b/src/polyfills/dgram.ts
@@ -1,6 +1,7 @@
 // stub - not available in browser
 
 import { EventEmitter } from "./events";
+import { getRegistry, type Handle } from "../helpers/event-loop";
 
 export interface Socket extends EventEmitter {
   bind(_port?: number, _addr?: string, _cb?: () => void): this;
@@ -32,16 +33,20 @@ export interface Socket extends EventEmitter {
 export const Socket = function Socket(this: any) {
   if (!this) return;
   EventEmitter.call(this);
+  this._elHandle = null;
 } as unknown as { new(): Socket; prototype: any };
 
 Object.setPrototypeOf(Socket.prototype, EventEmitter.prototype);
 
 Socket.prototype.bind = function bind(_port?: number, _addr?: string, _cb?: () => void) {
+  if (!this._elHandle) this._elHandle = getRegistry().register("UDPWrap");
   if (_cb) setTimeout(_cb, 0);
   return this;
 };
 
 Socket.prototype.close = function close(_cb?: () => void): void {
+  (this._elHandle as Handle | null)?.close();
+  this._elHandle = null;
   if (_cb) setTimeout(_cb, 0);
 };
 
@@ -67,8 +72,8 @@ Socket.prototype.setMulticastLoopback = function setMulticastLoopback(_flag: boo
 Socket.prototype.setMulticastInterface = function setMulticastInterface(_iface: string): void {};
 Socket.prototype.addMembership = function addMembership(_group: string, _iface?: string): void {};
 Socket.prototype.dropMembership = function dropMembership(_group: string, _iface?: string): void {};
-Socket.prototype.ref = function ref() { return this; };
-Socket.prototype.unref = function unref() { return this; };
+Socket.prototype.ref = function ref() { (this._elHandle as Handle | null)?.ref(); return this; };
+Socket.prototype.unref = function unref() { (this._elHandle as Handle | null)?.unref(); return this; };
 Socket.prototype.setRecvBufferSize = function setRecvBufferSize(_sz: number): void {};
 Socket.prototype.setSendBufferSize = function setSendBufferSize(_sz: number): void {};
 Socket.prototype.getRecvBufferSize = function getRecvBufferSize(): number { return 0; };

--- a/src/polyfills/esbuild.ts
+++ b/src/polyfills/esbuild.ts
@@ -4,7 +4,7 @@ import type { MemoryVolume } from "../memory-volume";
 import { CDN_ESBUILD_BINARY, CDN_ESBUILD_BROWSER, cdnImport } from "../constants/cdn-urls";
 import { stripTopLevelAwait } from "../syntax-transforms";
 import { ESBUILD_LOADER_MAP, RESOLVE_EXTENSIONS } from "../constants/config";
-import { ref, unref } from "../helpers/event-loop";
+import { getRegistry } from "../helpers/event-loop";
 
 const BUILTIN_MODULES = new Set([
   "assert",
@@ -171,13 +171,13 @@ export async function transform(
   source: string,
   cfg?: TransformConfig,
 ): Promise<TransformOutput> {
-  ref();
+  const h = getRegistry().register("EsbuildOp");
   try {
     if (!engine) await initialize();
     if (!engine) throw new Error("esbuild: engine not ready");
     return await engine.transform(source, cfg);
   } finally {
-    unref();
+    h.close();
   }
 }
 
@@ -186,7 +186,7 @@ export async function build(cfg: BundleConfig): Promise<BundleOutput> {
   if (!engine) throw new Error("esbuild: engine not ready");
 
   // keep event loop alive while building (Vite's dep optimizer is async)
-  ref();
+  const h = getRegistry().register("EsbuildOp");
   try {
     const volumePlugin = createVolumePlugin(cfg.external, cfg.platform, cfg.conditions);
     const allPlugins = [...(cfg.plugins || [])];
@@ -227,7 +227,7 @@ export async function build(cfg: BundleConfig): Promise<BundleOutput> {
 
     return raw;
   } finally {
-    unref();
+    h.close();
   }
 }
 
@@ -253,11 +253,11 @@ export async function context(cfg: BundleConfig): Promise<{
   cancel: () => Promise<void>;
   dispose: () => Promise<void>;
 }> {
-  ref();
+  const initHandle = getRegistry().register("EsbuildOp");
   try {
     if (!engine) await initialize();
   } finally {
-    unref();
+    initHandle.close();
   }
 
   let disposed = false;

--- a/src/polyfills/events.ts
+++ b/src/polyfills/events.ts
@@ -2,12 +2,15 @@
 // EventEmitter.call(this) and Object.create(EventEmitter.prototype) work.
 // ES6 classes forbid calling without `new`, which breaks tons of npm packages.
 
-import { ref, unref } from "../helpers/event-loop";
+import { isExitSentinel } from "../helpers/event-loop";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type EventHandler = (...args: any[]) => void;
 
-const DEFAULT_CEILING = 10;
+// node exposes EventEmitter.defaultMaxListeners as a mutable static. jest
+// sets it to 0 (meaning "unlimited") to silence the warning in its test
+// suite, pino does the same. module-level so reads and writes share state.
+let DEFAULT_CEILING = 10;
 
 // VFS->chokidar HMR bridge: chokidar's async fs.watch() setup chain doesn't
 // complete in browser, so we detect FSWatchers by _watched Map and bridge
@@ -97,6 +100,7 @@ export interface EventEmitterConstructor {
   (): void;
   prototype: EventEmitter;
   EventEmitter: EventEmitterConstructor;
+  defaultMaxListeners: number;
   listenerCount(target: EventEmitter, name: string): number;
   once(target: EventEmitter, name: string): Promise<unknown[]>;
   on(target: EventEmitter, name: string): AsyncIterable<unknown[]>;
@@ -175,30 +179,36 @@ EventEmitter.prototype.emit = function emit(name: string, ...payload: unknown[])
     return false;
   }
 
-  // if a handler returns a promise, hold a ref so the process doesn't bail early
-  const trackResult = (result: unknown) => {
-    if (result && typeof (result as any).then === "function") {
-      ref();
-      (result as Promise<unknown>).then(() => unref(), () => unref());
-    }
-  };
+  // node's EventEmitter.emit is fire-and-forget. returned Promises from
+  // async listeners are NOT awaited and do NOT keep the event loop alive.
+  // an earlier version of this polyfill registered a Handle per async
+  // listener Promise, which broke parity (any listener returning a
+  // never-settling Promise leaked a refed Handle, which e.g. made vite's
+  // `q` shortcut fail to exit). fire-and-forget is correct.
+  //
+  // process.exit() throws our branded ProcessExitSentinel and we let it
+  // propagate so the wait loop sees didExit and short-circuits the rest
+  // of the handlers. other errors swallowed (matches node's per-listener
+  // exception handling in events.js for non-error events).
 
-  // Fast path: single listener — avoid slice() allocation
+  // fast path: single listener, avoid slice()
   if (slot.length === 1) {
     try {
-      const r = slot[0].apply(this, payload);
-      trackResult(r);
-    } catch (_) { /* swallow */ }
+      slot[0].apply(this, payload);
+    } catch (e) {
+      if (isExitSentinel(e)) throw e;
+      /* ignore */
+    }
     return true;
   }
 
   const snapshot = slot.slice();
   for (const handler of snapshot) {
     try {
-      const r = handler.apply(this, payload);
-      trackResult(r);
-    } catch (fault) {
-      /* swallow handler errors */
+      handler.apply(this, payload);
+    } catch (e) {
+      if (isExitSentinel(e)) throw e;
+      /* ignore */
     }
   }
   return true;
@@ -250,6 +260,27 @@ EventEmitter.listenerCount = function (target: EventEmitter, name: string): numb
   return target.listenerCount(name);
 };
 
+// read/write through DEFAULT_CEILING so emitters created after a write
+// pick up the updated value
+Object.defineProperty(EventEmitter, "defaultMaxListeners", {
+  get() {
+    return DEFAULT_CEILING;
+  },
+  set(v: number) {
+    const n = Number(v);
+    // node accepts 0 (unlimited) and any positive integer, rejects negative
+    // or non-numeric.
+    if (!Number.isFinite(n) || n < 0) {
+      throw new RangeError(
+        `defaultMaxListeners must be a non-negative number; got ${v}`,
+      );
+    }
+    DEFAULT_CEILING = n;
+  },
+  enumerable: true,
+  configurable: true,
+});
+
 // supports both `import EventEmitter from 'events'` and `import { EventEmitter }`
 const moduleFacade = EventEmitter as EventEmitterConstructor & {
   EventEmitter: EventEmitterConstructor;
@@ -280,17 +311,86 @@ moduleFacade.once = async (
 };
 
 moduleFacade.on = (target: EventEmitter, name: string) => {
-  const asyncIter = {
+  // node's events.on(emitter, name) returns an async iterator that:
+  //  - buffers events as they arrive so nothing is dropped between awaits
+  //  - supports return()/throw() so `for await ... break/throw` cleans up
+  //    the internal listener instead of leaking it
+  //  - rejects on 'error' emitted from the source emitter
+  const unread: unknown[][] = [];
+  const waiting: Array<(r: { value: unknown[]; done: boolean }) => void> = [];
+  const rejecters: Array<(e: unknown) => void> = [];
+  let finished = false;
+  let errored: unknown = null;
+
+  const onEvent = (...args: unknown[]) => {
+    if (finished) return;
+    const w = waiting.shift();
+    rejecters.shift();
+    if (w) w({ value: args, done: false });
+    else unread.push(args);
+  };
+  const onError = (err: unknown) => {
+    if (finished) return;
+    errored = err;
+    cleanup();
+    const r = rejecters.shift();
+    waiting.shift();
+    if (r) r(err);
+  };
+  const cleanup = () => {
+    if (finished) return;
+    finished = true;
+    target.removeListener(name, onEvent);
+    target.removeListener("error", onError);
+  };
+
+  target.on(name, onEvent);
+  target.on("error", onError);
+
+  const iter: AsyncIterator<unknown[]> & AsyncIterable<unknown[]> = {
     async next() {
-      return new Promise<{ value: unknown[]; done: boolean }>((fulfill) => {
-        target.once(name, (...args) => fulfill({ value: args, done: false }));
-      });
+      if (errored) {
+        const e = errored;
+        errored = null;
+        throw e;
+      }
+      if (unread.length > 0) {
+        return { value: unread.shift() as unknown[], done: false };
+      }
+      if (finished) {
+        return { value: undefined as unknown as unknown[], done: true };
+      }
+      return new Promise<{ value: unknown[]; done: boolean }>(
+        (fulfill, reject) => {
+          waiting.push(fulfill);
+          rejecters.push(reject);
+        },
+      );
+    },
+    async return(value?: unknown) {
+      cleanup();
+      // wake pending awaiters so the for-await exits cleanly
+      while (waiting.length > 0) {
+        const w = waiting.shift();
+        rejecters.shift();
+        w?.({ value: undefined as unknown as unknown[], done: true });
+      }
+      return { value, done: true } as IteratorResult<unknown[]>;
+    },
+    async throw(err?: unknown) {
+      cleanup();
+      while (rejecters.length > 0) {
+        const r = rejecters.shift();
+        waiting.shift();
+        r?.(err);
+      }
+      throw err;
     },
     [Symbol.asyncIterator]() {
       return this;
     },
   };
-  return asyncIter as AsyncIterable<unknown[]>;
+  return iter;
 };
 
 moduleFacade.getEventListeners = (target: EventEmitter, name: string) =>

--- a/src/polyfills/fs.ts
+++ b/src/polyfills/fs.ts
@@ -13,6 +13,7 @@ import { precompileWasm } from "../helpers/wasm-cache";
 import { Readable, Writable } from "./stream";
 import { Buffer } from "./buffer";
 import type { FsReadStreamInstance, FsWriteStreamInstance, FsReadableState, FsWritableState } from "../types/fs-streams";
+import { getRegistry } from "../helpers/event-loop";
 
 export type { FileStat, FileWatchHandle, WatchCallback, WatchEventKind };
 
@@ -1265,8 +1266,17 @@ export function buildFileSystemBridge(
         if (resolve) { resolve(); resolve = null; }
       });
 
+      // keeps the loop alive while the iterator is open. abort/return releases
+      const elHandle = getRegistry().register("FSWatcher");
+      const releaseAll = () => {
+        if (closed) return;
+        closed = true;
+        handle.close();
+        elHandle.close();
+      };
+
       if (opts?.signal) {
-        opts.signal.addEventListener("abort", () => { closed = true; handle.close(); if (resolve) { resolve(); resolve = null; } }, { once: true });
+        opts.signal.addEventListener("abort", () => { releaseAll(); if (resolve) { resolve(); resolve = null; } }, { once: true });
       }
 
       return {
@@ -1285,8 +1295,7 @@ export function buildFileSystemBridge(
               });
             },
             return(): Promise<IteratorResult<{ eventType: string; filename: string | null }>> {
-              closed = true;
-              handle.close();
+              releaseAll();
               return Promise.resolve({ value: undefined as any, done: true });
             },
           };
@@ -1737,11 +1746,31 @@ export function buildFileSystemBridge(
       cb?: WatchCallback,
     ): FileWatchHandle {
       const p = abs(filename);
-      return volume.watch(
+      const inner = volume.watch(
         p,
         optsOrCb as { persistent?: boolean; recursive?: boolean },
         cb,
       );
+      // hold a Handle for the loop and wrap close() to release it. ref/unref
+      // mirror node's FSWatcher API so watcher.unref() lets the process exit
+      // without having to close the watcher first.
+      const elHandle = getRegistry().register("FSWatcher");
+      const origClose = inner.close?.bind(inner);
+      if (origClose) {
+        inner.close = () => {
+          origClose();
+          elHandle.close();
+        };
+      }
+      (inner as any).ref = () => {
+        elHandle.ref();
+        return inner;
+      };
+      (inner as any).unref = () => {
+        elHandle.unref();
+        return inner;
+      };
+      return inner;
     },
 
     watchFile(

--- a/src/polyfills/http.ts
+++ b/src/polyfills/http.ts
@@ -7,7 +7,7 @@ import { Readable, Writable } from "./stream";
 import { Buffer } from "./buffer";
 import { TcpSocket, TcpServer, type NetAddress } from "./net";
 import { createHash } from "./crypto";
-import { ref as _elRef, unref as _elUnref } from "../helpers/event-loop";
+// no event-loop import, the net.Server under us already registers TCPServerWrap
 import { TIMEOUTS } from "../constants/config";
 
 // capture real browser WebSocket before any bundled lib can overwrite it
@@ -1213,14 +1213,14 @@ let _onBind: RegistryHook | null = null;
 let _onUnbind: ((port: number) => void) | null = null;
 
 function _addServer(port: number, srv: Server, ownerPid?: number): void {
+  // loop liveness is held by the inner net.TcpServer's TCPServerWrap handle.
+  // this registry is just the port -> Server map for internal routing.
   _registry.set(port, srv);
   if (ownerPid !== undefined) _serverOwnership.set(port, ownerPid);
-  _elRef(); // server keeps the process alive
   if (_onBind) _onBind(port, srv);
 }
 
 function _removeServer(port: number): void {
-  if (_registry.has(port)) _elUnref(); // server no longer keeps process alive
   _registry.delete(port);
   _serverOwnership.delete(port);
   if (_onUnbind) _onUnbind(port);

--- a/src/polyfills/http2.ts
+++ b/src/polyfills/http2.ts
@@ -2,6 +2,7 @@
 
 
 import { EventEmitter } from "./events";
+import { getRegistry, type Handle } from "../helpers/event-loop";
 
 /* ------------------------------------------------------------------ */
 /*  Sessions                                                           */
@@ -22,22 +23,28 @@ export interface Http2Session extends EventEmitter {
 export const Http2Session = function Http2Session(this: any) {
   if (!this) return;
   EventEmitter.call(this);
+  this._elHandle = getRegistry().register("HTTP2Session");
 } as unknown as { new(): Http2Session; prototype: any };
 
 Object.setPrototypeOf(Http2Session.prototype, EventEmitter.prototype);
 
 Http2Session.prototype.close = function close(done?: () => void): void {
+  (this._elHandle as Handle | null)?.close();
+  this._elHandle = null;
   if (done) setTimeout(done, 0);
 };
-Http2Session.prototype.destroy = function destroy(_err?: Error, _code?: number): void {};
+Http2Session.prototype.destroy = function destroy(_err?: Error, _code?: number): void {
+  (this._elHandle as Handle | null)?.close();
+  this._elHandle = null;
+};
 Object.defineProperty(Http2Session.prototype, 'destroyed', { get() { return false; }, configurable: true });
 Object.defineProperty(Http2Session.prototype, 'encrypted', { get() { return false; }, configurable: true });
 Object.defineProperty(Http2Session.prototype, 'closed', { get() { return false; }, configurable: true });
 Http2Session.prototype.ping = function ping(
   _cb: (err: Error | null, dur: number, buf: Uint8Array) => void,
 ): boolean { return false; };
-Http2Session.prototype.ref = function ref(): void {};
-Http2Session.prototype.unref = function unref(): void {};
+Http2Session.prototype.ref = function ref(): void { (this._elHandle as Handle | null)?.ref(); };
+Http2Session.prototype.unref = function unref(): void { (this._elHandle as Handle | null)?.unref(); };
 Http2Session.prototype.setTimeout = function setTimeout(_ms: number, _cb?: () => void): void {};
 
 export interface ClientHttp2Session extends Http2Session {}

--- a/src/polyfills/net.ts
+++ b/src/polyfills/net.ts
@@ -4,6 +4,7 @@ import { EventEmitter, type EventHandler } from "./events";
 import { Duplex } from "./stream";
 import { Buffer } from "./buffer";
 import { PORT_RANGE } from "../constants/config";
+import { getRegistry, type Handle } from "../helpers/event-loop";
 
 
 export interface NetAddress {
@@ -120,6 +121,9 @@ TcpSocket.prototype.connect = function connect(
   this.remoteFamily = "IPv4";
   this.readyState = "opening";
 
+  // keep the loop alive while connected, released on destroy
+  if (!this._elHandle) this._elHandle = getRegistry().register("TCPSocketWrap");
+
   const self = this;
   queueMicrotask(() => {
     self._isConnecting = false;
@@ -156,10 +160,12 @@ TcpSocket.prototype.setKeepAlive = function setKeepAlive(_on?: boolean, _delay?:
 };
 
 TcpSocket.prototype.ref = function ref(): any {
+  (this._elHandle as Handle | null)?.ref();
   return this;
 };
 
 TcpSocket.prototype.unref = function unref(): any {
+  (this._elHandle as Handle | null)?.unref();
   return this;
 };
 
@@ -169,6 +175,8 @@ TcpSocket.prototype.destroy = function destroy(err?: Error): any {
   this._isConnected = false;
   this.destroyed = true;
   this.readyState = "closed";
+  (this._elHandle as Handle | null)?.close();
+  this._elHandle = null;
   if (err) this.emit("error", err);
   const self = this;
   queueMicrotask(() => self.emit("close", !!err));
@@ -258,6 +266,9 @@ TcpServer.prototype.listen = function listen(
   this._bound = true;
   this.listening = true;
 
+  // keep the loop alive while listening, released on close
+  if (!this._elHandle) this._elHandle = getRegistry().register("TCPServerWrap");
+
   const self = this;
   queueMicrotask(() => {
     self.emit("listening");
@@ -277,6 +288,8 @@ TcpServer.prototype.close = function close(cb?: (err?: Error) => void): any {
   this.listening = false;
   for (const s of this._peers) s.destroy();
   this._peers.clear();
+  (this._elHandle as Handle | null)?.close();
+  this._elHandle = null;
   const self = this;
   queueMicrotask(() => {
     self.emit("close");
@@ -292,10 +305,12 @@ TcpServer.prototype.getConnections = function getConnections(
 };
 
 TcpServer.prototype.ref = function ref(): any {
+  (this._elHandle as Handle | null)?.ref();
   return this;
 };
 
 TcpServer.prototype.unref = function unref(): any {
+  (this._elHandle as Handle | null)?.unref();
   return this;
 };
 

--- a/src/polyfills/process.ts
+++ b/src/polyfills/process.ts
@@ -10,6 +10,11 @@ import {
   DEFAULT_ENV,
   DEFAULT_TERMINAL,
 } from "../constants/config";
+import {
+  getRegistry,
+  ProcessExitSentinel,
+  type Handle,
+} from "./../helpers/event-loop";
 
 // capture before engine wrapper overrides globalThis.console
 const _nativeConsole = console;
@@ -90,6 +95,12 @@ export interface ProcessObject {
   execArgv: string[];
   pid: number;
   ppid: number;
+  /**
+   * undefined by default. user code can set this to seed an exit code for
+   * process.exit() (no arg) or natural drain. process.exit(N) overrides
+   * and writes N back here.
+   */
+  exitCode?: number;
   exit: (code?: number) => never;
   nextTick: (fn: (...args: unknown[]) => void, ...args: unknown[]) => void;
   stdout: OutputStreamBridge;
@@ -171,6 +182,7 @@ export interface ProcessObject {
   reallyExit?: (code?: number) => void;
   _getActiveRequests?: () => unknown[];
   _getActiveHandles?: () => unknown[];
+  getActiveResourcesInfo?: () => string[];
   emitWarning?: (
     warning: string | Error,
     typeOrOptions?: string | { type?: string; code?: string; detail?: string },
@@ -202,6 +214,61 @@ function fabricateStream(
   let _cols: number = DEFAULT_TERMINAL.COLUMNS;
   let _rows: number = DEFAULT_TERMINAL.ROWS;
 
+  // stdin ref tracking. node refs the loop while stdin's read side is in
+  // flowing mode. .on('data') auto-resumes, .pause() unrefs. removing a
+  // data listener does NOT auto-pause in node, callers must call .pause()
+  // explicitly (readline.Interface.close() does that for you). output
+  // streams never hold the loop alive.
+  //
+  // 'readable' listeners do NOT ref the loop in node: the stream stays
+  // paused until the user calls .read(). only flowing-mode listeners
+  // ('data') and explicit .resume() keep us alive.
+  //
+  // refcount rather than a boolean so two independent subsystems (e.g. a
+  // readline.Interface and a direct process.stdin.on('data') consumer)
+  // don't stomp each other: a single .pause() won't release the handle
+  // while another consumer still expects data.
+  let _stdinHandle: Handle | null = null;
+  let _stdinRefCount = 0;
+  const _stdinRef = () => {
+    if (isOutput) return;
+    _stdinRefCount++;
+    if (!_stdinHandle) _stdinHandle = getRegistry().register("TTYWrap");
+  };
+  const _stdinUnref = () => {
+    if (isOutput) return;
+    if (_stdinRefCount === 0) return;
+    _stdinRefCount--;
+    if (_stdinRefCount === 0 && _stdinHandle) {
+      _stdinHandle.close();
+      _stdinHandle = null;
+    }
+  };
+
+  // buffer 'data' emits that arrive before any 'data' listener is attached.
+  // real node's stdin is a Readable in paused mode, so it holds bytes in
+  // its internal buffer until a consumer attaches and then flushes on
+  // attach/resume. our stream is backed by a bare EventEmitter so without
+  // this any pre-listener emit is silently dropped. showed up as vite's
+  // ~3s gap between "ready" and bindCLIShortcuts attaching readline
+  // eating every keystroke typed during the gap.
+  const _pendingData: unknown[][] = [];
+
+  const _flushPendingData = () => {
+    if (isOutput || _pendingData.length === 0) return;
+    // snapshot and clear sync so a handler that schedules another sendStdin
+    // during replay doesn't get re-replayed here
+    const pending = _pendingData.splice(0);
+    // queueMicrotask so the just-added listener is definitely registered
+    // (sync call sites expect .on('data', fn).something() chains to finish
+    // before data fires), and it matches node's flush-on-next-tick feel
+    queueMicrotask(() => {
+      for (const args of pending) {
+        bus.emit("data", ...(args as unknown[]));
+      }
+    });
+  };
+
   const stream: OutputStreamBridge & InputStreamBridge = {
     isTTY: false,
     columns: DEFAULT_TERMINAL.COLUMNS,
@@ -209,10 +276,21 @@ function fabricateStream(
     isRaw: false,
     on(evt, fn) {
       bus.on(evt, fn);
+      // node auto-resumes stdin (refs loop) only for flowing mode, i.e.
+      // 'data' listeners. 'readable' keeps the stream paused until the
+      // user calls .read(), so we must NOT ref here.
+      if (!isOutput && evt === "data") {
+        _stdinRef();
+        _flushPendingData();
+      }
       return stream;
     },
     once(evt, fn) {
       bus.once(evt, fn);
+      if (!isOutput && evt === "data") {
+        _stdinRef();
+        _flushPendingData();
+      }
       return stream;
     },
     off(evt, fn) {
@@ -220,10 +298,21 @@ function fabricateStream(
       return stream;
     },
     emit(evt, ...args) {
+      // stdin 'data' arriving with no listener: queue instead of dropping,
+      // replay when a listener attaches (see _flushPendingData above)
+      if (!isOutput && evt === "data" && bus.listenerCount("data") === 0) {
+        _pendingData.push(args);
+        // EventEmitter.emit returns true iff a listener was called, none here
+        return false;
+      }
       return bus.emit(evt, ...args);
     },
     addListener(evt, fn) {
       bus.addListener(evt, fn);
+      if (!isOutput && evt === "data") {
+        _stdinRef();
+        _flushPendingData();
+      }
       return stream;
     },
     removeListener(evt, fn) {
@@ -252,19 +341,29 @@ function fabricateStream(
     },
     prependListener(evt, fn) {
       bus.prependListener(evt, fn);
+      if (!isOutput && evt === "data") {
+        _stdinRef();
+        _flushPendingData();
+      }
       return stream;
     },
     prependOnceListener(evt, fn) {
       bus.prependOnceListener(evt, fn);
+      if (!isOutput && evt === "data") {
+        _stdinRef();
+        _flushPendingData();
+      }
       return stream;
     },
     eventNames() {
       return bus.eventNames();
     },
     pause() {
+      _stdinUnref();
       return stream;
     },
     resume() {
+      _stdinRef();
       return stream;
     },
     setEncoding(_enc) {
@@ -296,6 +395,10 @@ function fabricateStream(
         if (dest.write) dest.write(chunk);
       };
       bus.on("data", onData);
+      // pipe attaches straight to the bus, bypassing stream.on(), so we
+      // still need to flush any pre-pipe buffered input. otherwise data
+      // typed before the consumer attached gets dropped.
+      if (!isOutput) _flushPendingData();
       if (!(stream as any)._pipeDests) (stream as any)._pipeDests = [];
       (stream as any)._pipeDests.push({ dest, onData });
       return dest;
@@ -546,10 +649,19 @@ export function buildProcessEnv(config?: {
     pid: config?.pid ?? MOCK_PROCESS.PID,
     ppid: config?.ppid ?? MOCK_PROCESS.PPID,
 
-    exit(code = 0) {
-      bus.emit("exit", code);
-      if (config?.onExit) config.onExit(code);
-      throw new Error(`Process exited with code ${code}`);
+    // process.exit() with no argument uses process.exitCode, process.exit(N)
+    // overrides exitCode and uses N. matches node.
+    exit(code?: number) {
+      const resolved =
+        typeof code === "number"
+          ? code
+          : typeof proc.exitCode === "number"
+            ? proc.exitCode
+            : 0;
+      proc.exitCode = resolved;
+      bus.emit("exit", resolved);
+      if (config?.onExit) config.onExit(resolved);
+      throw new ProcessExitSentinel(resolved);
     },
 
     nextTick(fn, ...args) {
@@ -689,11 +801,34 @@ export function buildProcessEnv(config?: {
       throw new Error("process.dlopen is not supported in browser environment");
     },
     reallyExit(_code?: number): void {},
+    // libuv splits handles (long-lived: timers, sockets, servers) from
+    // requests (short-lived: fs ops, fetches, imports). we map our
+    // HandleType enum onto that split for introspection parity.
     _getActiveRequests(): unknown[] {
-      return [];
+      const reqTypes = new Set<string>([
+        "FSReqCallback", "FetchRequest", "DynamicImport", "WASMWork",
+      ]);
+      return getRegistry()
+        .list()
+        .filter((h) => h.refed && reqTypes.has(h.type))
+        .map((h) => ({ type: h.type }));
     },
     _getActiveHandles(): unknown[] {
-      return [];
+      const reqTypes = new Set<string>([
+        "FSReqCallback", "FetchRequest", "DynamicImport", "WASMWork",
+      ]);
+      return getRegistry()
+        .list()
+        .filter((h) => h.refed && !reqTypes.has(h.type))
+        .map((h) => ({ type: h.type }));
+    },
+    // node 17.3+: plain string[] of active resource types.
+    // see lib/internal/process/per_thread.js.
+    getActiveResourcesInfo(): string[] {
+      return getRegistry()
+        .list()
+        .filter((h) => h.refed)
+        .map((h) => h.type);
     },
     emitWarning(
       warning: string | Error,

--- a/src/polyfills/readline.ts
+++ b/src/polyfills/readline.ts
@@ -2,7 +2,7 @@
 // we track line/cursor on every keystroke because @clack reads rl.line directly
 
 import { EventEmitter } from "./events";
-import { ref as _elRef, unref as _elUnref } from "../helpers/event-loop";
+import { getRegistry, type Handle } from "../helpers/event-loop";
 
 // the wait loop checks this so it doesn't bail while the user is typing
 let _activeInterfaceCount = 0;
@@ -246,6 +246,8 @@ export interface Interface extends EventEmitter {
   pause(): this;
   resume(): this;
   close(): void;
+  ref(): this;
+  unref(): this;
   write(data: string | null, _key?: { ctrl?: boolean; name?: string; meta?: boolean; shift?: boolean; sequence?: string }): void;
   clearLine(dir?: number): void;
   getCursorPos(): { rows: number; cols: number };
@@ -267,7 +269,17 @@ export const Interface = function Interface(this: any, cfg?: InterfaceConfig) {
   this.closed = false;
   this._lineBuffer = "";
   this._pendingQuestions = [];
-  this.terminal = cfg?.terminal ?? false;
+  // node auto-detects terminal from input.isTTY (and output.isTTY when
+  // output is set). without this, createInterface({input: process.stdin})
+  // falls back to line mode and emitKeypressEvents never runs, which
+  // breaks vite's q-shortcut handler.
+  if (cfg?.terminal !== undefined) {
+    this.terminal = cfg.terminal;
+  } else {
+    const inputIsTTY = !!(cfg?.input as any)?.isTTY;
+    const outputIsTTY = !!(cfg?.output as any)?.isTTY;
+    this.terminal = inputIsTTY && (cfg?.output == null || outputIsTTY);
+  }
   this.line = "";
   this.cursor = 0;
 
@@ -290,9 +302,19 @@ export const Interface = function Interface(this: any, cfg?: InterfaceConfig) {
 
   if (this.input && typeof (this.input as any).on === "function") {
     _activeInterfaceCount++;
-    _elRef();
+    (this as any)._elHandle = getRegistry().register("ReadlineInterface");
     const inputStream = this.input as EventEmitter;
     const self = this;
+
+    // remember every listener we attach so close() can drop them. otherwise
+    // each closed readline leaves dead keypress/data/end handlers on stdin
+    // and they pile up across lifecycles.
+    const installed: Array<{ evt: string; fn: (...a: any[]) => void }> = [];
+    const installAndTrack = (evt: string, fn: (...a: any[]) => void) => {
+      inputStream.on(evt, fn);
+      installed.push({ evt, fn });
+    };
+    (this as any)._installedListeners = installed;
 
     if (this.terminal) {
       // raw mode so we get individual keystrokes instead of line-buffered input
@@ -302,19 +324,19 @@ export const Interface = function Interface(this: any, cfg?: InterfaceConfig) {
 
       emitKeypressEvents(this.input, this);
 
-      inputStream.on("keypress", (char: string | undefined, key: any) => {
+      installAndTrack("keypress", (char: string | undefined, key: any) => {
         if (self.closed) return;
         self._onKeypress(char, key);
       });
     } else {
-      inputStream.on("data", (data: unknown) => {
+      installAndTrack("data", (data: unknown) => {
         if (self.closed) return;
         const text = typeof data === "string" ? data : String(data);
         self._onData(text);
       });
     }
 
-    inputStream.on("end", () => {
+    installAndTrack("end", () => {
       if (!self.closed) self.close();
     });
   }
@@ -744,6 +766,20 @@ Interface.prototype.resume = function resume(this: any): any {
   return this;
 };
 
+// node's Interface.ref/unref lets users opt out of keeping the loop alive
+// while the interface is still open. forward to our Handle.
+Interface.prototype.ref = function ref(this: any): any {
+  const h = (this as any)._elHandle as Handle | undefined;
+  if (h) h.ref();
+  return this;
+};
+
+Interface.prototype.unref = function unref(this: any): any {
+  const h = (this as any)._elHandle as Handle | undefined;
+  if (h) h.unref();
+  return this;
+};
+
 Interface.prototype.close = function close(this: any): void {
   if (this.closed) return;
   this.closed = true;
@@ -753,7 +789,29 @@ Interface.prototype.close = function close(this: any): void {
   }
   if (this.input && typeof (this.input as any).on === "function") {
     _activeInterfaceCount = Math.max(0, _activeInterfaceCount - 1);
-    _elUnref();
+    const h = (this as any)._elHandle as Handle | undefined;
+    if (h) {
+      h.close();
+      (this as any)._elHandle = undefined;
+    }
+    // drop the listeners we put on input. otherwise a long-lived stdin keeps
+    // a stack of dead handlers (keypress/data/end) from every past readline,
+    // which starts interfering with later ones on the same stdin (e.g.
+    // create-vite's prompts vs vite's q-shortcut).
+    const installed = (this as any)._installedListeners as
+      | Array<{ evt: string; fn: (...a: any[]) => void }>
+      | undefined;
+    if (installed && typeof (this.input as any).removeListener === "function") {
+      for (const { evt, fn } of installed) {
+        try { (this.input as any).removeListener(evt, fn); } catch { /* ignore */ }
+      }
+      installed.length = 0;
+    }
+    // pause the input so the process can exit once the readline is gone.
+    // node's stdin handle unrefs on pause and releases the loop.
+    if (typeof (this.input as any).pause === "function") {
+      try { (this.input as any).pause(); } catch { /* ignore */ }
+    }
   }
   // answer any pending questions with empty string
   for (const q of this._pendingQuestions) {

--- a/src/polyfills/timers.ts
+++ b/src/polyfills/timers.ts
@@ -1,24 +1,335 @@
-// Timer functions mapped to browser equivalents, includes setImmediate polyfill
+// timer polyfills with Handle tracking. every setTimeout/setInterval/
+// setImmediate registers a typed Handle in the active HandleRegistry so the
+// event loop knows about it. handles auto-close when a one-shot fires or
+// the timer is cleared. script-engine's globalThis patch routes through
+// here too, so `node:timers` and bare setTimeout share the same path.
 
+import {
+  getRegistry,
+  isExitSentinel,
+  type Handle,
+  type HandleType,
+} from "../helpers/event-loop";
 
-export const setTimeout = globalThis.setTimeout;
-export const setInterval = globalThis.setInterval;
-export const setImmediate = (fn: (...args: unknown[]) => void, ...args: unknown[]) =>
-  globalThis.setTimeout(fn, 0, ...args);
-export const clearTimeout = globalThis.clearTimeout;
-export const clearInterval = globalThis.clearInterval;
-export const clearImmediate = globalThis.clearTimeout;
+// keep references to the raw browser timer functions. captured at import
+// so later patches of globalThis.setTimeout don't recurse through us.
+const _rawSetTimeout = globalThis.setTimeout.bind(globalThis);
+const _rawSetInterval = globalThis.setInterval.bind(globalThis);
+const _rawClearTimeout = globalThis.clearTimeout.bind(globalThis);
+const _rawClearInterval = globalThis.clearInterval.bind(globalThis);
 
-// timers/promises API
+// node's TIMEOUT_MAX = 2^31 - 1. anything outside [1, TIMEOUT_MAX] (NaN,
+// negative, non-finite, non-numeric) is coerced to 1. matches
+// lib/internal/timers.js#getTimerDuration in node source.
+const TIMEOUT_MAX = 2147483647;
+
+function normalizeDelay(ms: unknown): number {
+  const n = typeof ms === "number" ? ms : Number(ms);
+  if (!Number.isFinite(n) || n < 1) return 1;
+  if (n > TIMEOUT_MAX) return 1;
+  return n;
+}
+
+export interface TimeoutLike {
+  _id: ReturnType<typeof _rawSetTimeout>;
+  _handle: Handle;
+  _isInterval: boolean;
+  _fired: boolean;
+  ref(): TimeoutLike;
+  unref(): TimeoutLike;
+  hasRef(): boolean;
+  refresh(): TimeoutLike;
+  [Symbol.toPrimitive](): number;
+}
+
+function makeTimeout(
+  kind: HandleType,
+  callback: (...args: unknown[]) => void,
+  msRaw: number,
+  args: unknown[],
+  isInterval: boolean,
+): TimeoutLike {
+  const ms = normalizeDelay(msRaw);
+  const handle = getRegistry().register(kind);
+  const self = {} as TimeoutLike;
+  self._isInterval = isInterval;
+  self._fired = false;
+  self._handle = handle;
+
+  const fire = () => {
+    if (!isInterval) {
+      self._fired = true;
+      handle.close();
+    }
+    try {
+      // widen the declared void return so we can duck-type async callbacks.
+      // setTimeout(async () => {...}) returns a Promise and plenty of user
+      // code depends on that even though node's types say void.
+      const r: unknown = callback(...args);
+      // if the callback is async, a process.exit() inside it becomes a
+      // Promise rejection, not a sync throw, so the try/catch below can't
+      // see it. filter the sentinel out of the rejection path to match
+      // node (process.exit inside a timer doesn't surface as an unhandled
+      // rejection). other rejections propagate normally.
+      if (r && typeof (r as { then?: unknown }).then === "function") {
+        (r as Promise<unknown>).then(undefined, (e: unknown) => {
+          if (isExitSentinel(e)) return;
+          // re-raise on the next microtask so it reaches the global
+          // unhandledrejection handler, same as node.
+          queueMicrotask(() => { throw e as Error; });
+        });
+      }
+    } catch (e) {
+      if (isExitSentinel(e)) return;
+      throw e;
+    }
+  };
+
+  self._id = isInterval
+    ? _rawSetInterval(fire, ms)
+    : _rawSetTimeout(fire, ms);
+
+  self.ref = () => {
+    if (!self._fired) handle.ref();
+    return self;
+  };
+  self.unref = () => {
+    handle.unref();
+    return self;
+  };
+  self.hasRef = () => handle.refed;
+
+  // Timeout.refresh() re-arms the timer with its original delay, cancelling
+  // any pending fire. undici, ws heartbeats, node-fetch, socket.io and many
+  // others rely on this; a no-op here breaks those libraries silently.
+  self.refresh = () => {
+    if (handle.closed) return self;
+    if (isInterval) {
+      _rawClearInterval(self._id);
+      self._id = _rawSetInterval(fire, ms);
+    } else {
+      _rawClearTimeout(self._id);
+      // refresh resurrects a one-shot Timeout: if it already fired we need
+      // to re-register the handle so the loop counts it again.
+      if (self._fired) {
+        self._fired = false;
+        handle.ref();
+      }
+      self._id = _rawSetTimeout(fire, ms);
+    }
+    return self;
+  };
+
+  self[Symbol.toPrimitive] = () => self._id as unknown as number;
+
+  return self;
+}
+
+// setImmediate approximation of node's check phase. node runs setImmediate
+// callbacks after I/O + microtasks and before the next timer tick, in
+// scheduling order. we approximate this by queueing into an array and
+// draining via a single MessageChannel message per flush cycle (the
+// closest browser analogue to the check phase). callbacks enqueued during
+// a flush run in the next cycle, not the current one, which preserves the
+// scheduling order without collapsing into setTimeout(0).
+
+interface ImmediateEntry {
+  handle: Handle;
+  cb: (...args: unknown[]) => void;
+  args: unknown[];
+  cleared: boolean;
+}
+
+const _immediateQueue: ImmediateEntry[] = [];
+let _immediateScheduled = false;
+
+// MessageChannel is the "check" trampoline. falls back to queueMicrotask
+// in environments without it (sandboxed workers without structured-clone).
+// both run after the current microtask queue drains, which is what matters
+// for nextTick/Promise ordering.
+let _scheduleCheck: () => void;
+if (typeof MessageChannel !== "undefined") {
+  const _mc = new MessageChannel();
+  _mc.port1.onmessage = () => _flushImmediates();
+  _scheduleCheck = () => _mc.port2.postMessage(0);
+} else {
+  _scheduleCheck = () => queueMicrotask(_flushImmediates);
+}
+
+function _flushImmediates(): void {
+  _immediateScheduled = false;
+  // snapshot: entries added during flush run in the next cycle
+  const batch = _immediateQueue.splice(0);
+  for (const entry of batch) {
+    if (entry.cleared) continue;
+    entry.handle.close();
+    try {
+      const r: unknown = entry.cb(...entry.args);
+      if (r && typeof (r as { then?: unknown }).then === "function") {
+        (r as Promise<unknown>).then(undefined, (e: unknown) => {
+          if (isExitSentinel(e)) return;
+          queueMicrotask(() => { throw e as Error; });
+        });
+      }
+    } catch (e) {
+      if (isExitSentinel(e)) continue;
+      // surface other throws as unhandled errors like node does
+      queueMicrotask(() => { throw e as Error; });
+    }
+  }
+  if (_immediateQueue.length > 0 && !_immediateScheduled) {
+    _immediateScheduled = true;
+    _scheduleCheck();
+  }
+}
+
+function makeImmediate(
+  cb: (...args: unknown[]) => void,
+  args: unknown[],
+): TimeoutLike {
+  const handle = getRegistry().register("Immediate");
+  const entry: ImmediateEntry = { handle, cb, args, cleared: false };
+  const self = {} as TimeoutLike;
+  self._isInterval = false;
+  self._fired = false;
+  self._handle = handle;
+  // no raw timer id here, stash the entry pointer for clearImmediate
+  self._id = entry as unknown as ReturnType<typeof _rawSetTimeout>;
+  self.ref = () => {
+    if (!entry.cleared) handle.ref();
+    return self;
+  };
+  self.unref = () => {
+    handle.unref();
+    return self;
+  };
+  self.hasRef = () => handle.refed;
+  self.refresh = () => self; // setImmediate handles have no meaningful refresh
+  self[Symbol.toPrimitive] = () => 0 as number;
+  _immediateQueue.push(entry);
+  if (!_immediateScheduled) {
+    _immediateScheduled = true;
+    _scheduleCheck();
+  }
+  return self;
+}
+
+export function setTimeout(
+  callback: (...args: unknown[]) => void,
+  ms?: number,
+  ...args: unknown[]
+): TimeoutLike {
+  return makeTimeout("Timeout", callback, ms ?? 0, args, false);
+}
+
+export function setInterval(
+  callback: (...args: unknown[]) => void,
+  ms?: number,
+  ...args: unknown[]
+): TimeoutLike {
+  return makeTimeout("Interval", callback, ms ?? 0, args, true);
+}
+
+export function setImmediate(
+  callback: (...args: unknown[]) => void,
+  ...args: unknown[]
+): TimeoutLike {
+  return makeImmediate(callback, args);
+}
+
+export function clearTimeout(t: unknown): void {
+  if (t && typeof t === "object" && "_id" in t && "_handle" in t) {
+    const timer = t as TimeoutLike;
+    // setImmediate handles use the ImmediateEntry as _id; detect and mark
+    const id = timer._id as unknown;
+    if (id && typeof id === "object" && "cleared" in (id as object)) {
+      (id as ImmediateEntry).cleared = true;
+    } else {
+      _rawClearTimeout(timer._id);
+    }
+    timer._handle.close();
+    return;
+  }
+  // plain numeric id passthrough (legacy code paths)
+  _rawClearTimeout(t as number);
+}
+
+export function clearInterval(t: unknown): void {
+  if (t && typeof t === "object" && "_id" in t && "_handle" in t) {
+    const timer = t as TimeoutLike;
+    _rawClearInterval(timer._id);
+    timer._handle.close();
+    return;
+  }
+  _rawClearInterval(t as number);
+}
+
+export function clearImmediate(t: unknown): void {
+  // clearTimeout handles the ImmediateEntry path. kept as a separate export
+  // for consumers that pattern-match on the name.
+  clearTimeout(t);
+}
+
+// timers/promises API. each awaited call owns a Handle for the life of the
+// Promise. aborted promises release via the abort path.
 export const promises = {
-  setTimeout: (ms: number, value?: unknown) =>
-    new Promise((resolve) => globalThis.setTimeout(() => resolve(value), ms)),
-  setInterval: globalThis.setInterval,
-  setImmediate: (value?: unknown) =>
-    new Promise((resolve) => globalThis.setTimeout(() => resolve(value), 0)),
+  setTimeout: (ms: number, value?: unknown, opts?: { signal?: AbortSignal }) =>
+    new Promise((resolve, reject) => {
+      const handle = getRegistry().register("Timeout");
+      const id = _rawSetTimeout(() => {
+        handle.close();
+        resolve(value);
+      }, normalizeDelay(ms));
+      if (opts?.signal) {
+        if (opts.signal.aborted) {
+          _rawClearTimeout(id);
+          handle.close();
+          reject(new DOMException("The operation was aborted", "AbortError"));
+          return;
+        }
+        opts.signal.addEventListener(
+          "abort",
+          () => {
+            _rawClearTimeout(id);
+            handle.close();
+            reject(new DOMException("The operation was aborted", "AbortError"));
+          },
+          { once: true },
+        );
+      }
+    }),
+
+  setInterval: setInterval,
+
+  // routes through the real check-phase queue so ordering matches setImmediate
+  setImmediate: (value?: unknown, opts?: { signal?: AbortSignal }) =>
+    new Promise((resolve, reject) => {
+      if (opts?.signal?.aborted) {
+        reject(new DOMException("The operation was aborted", "AbortError"));
+        return;
+      }
+      const im = makeImmediate(() => resolve(value), []);
+      if (opts?.signal) {
+        opts.signal.addEventListener(
+          "abort",
+          () => {
+            clearImmediate(im);
+            reject(new DOMException("The operation was aborted", "AbortError"));
+          },
+          { once: true },
+        );
+      }
+    }),
+
   scheduler: {
     wait: (ms: number) =>
-      new Promise((resolve) => globalThis.setTimeout(resolve, ms)),
+      new Promise((resolve) => {
+        const handle = getRegistry().register("Timeout");
+        _rawSetTimeout(() => {
+          handle.close();
+          resolve(undefined);
+        }, normalizeDelay(ms));
+      }),
   },
 };
 
@@ -29,4 +340,5 @@ export default {
   clearTimeout,
   clearInterval,
   clearImmediate,
+  promises,
 };

--- a/src/polyfills/worker_threads.ts
+++ b/src/polyfills/worker_threads.ts
@@ -3,7 +3,7 @@
 
 
 import { EventEmitter } from "./events";
-import { ref as eventLoopRef, unref as eventLoopUnref } from "../helpers/event-loop";
+import { getRegistry, type Handle } from "../helpers/event-loop";
 
 // shared defaults for main thread; child workers get per-engine overrides via buildResolver
 export let isMainThread = true;
@@ -66,15 +66,27 @@ interface MessagePortConstructor {
 export const MessagePort = function MessagePort(this: any) {
   if (!this) return;
   EventEmitter.call(this);
+  // starts unref'd, node refs on start()
+  this._elHandle = null;
 } as unknown as MessagePortConstructor;
 
 Object.setPrototypeOf(MessagePort.prototype, EventEmitter.prototype);
 
 MessagePort.prototype.postMessage = function postMessage(_val: unknown, _transfer?: unknown[]): void {};
-MessagePort.prototype.start = function start(): void {};
-MessagePort.prototype.close = function close(): void {};
-MessagePort.prototype.ref = function ref(): void {};
-MessagePort.prototype.unref = function unref(): void {};
+MessagePort.prototype.start = function start(this: any): void {
+  if (!this._elHandle) this._elHandle = getRegistry().register("MessagePort");
+};
+MessagePort.prototype.close = function close(this: any): void {
+  (this._elHandle as Handle | null)?.close();
+  this._elHandle = null;
+};
+MessagePort.prototype.ref = function ref(this: any): void {
+  if (!this._elHandle) this._elHandle = getRegistry().register("MessagePort");
+  else this._elHandle.ref();
+};
+MessagePort.prototype.unref = function unref(this: any): void {
+  (this._elHandle as Handle | null)?.unref();
+};
 
 
 export interface MessageChannel {
@@ -110,7 +122,7 @@ export interface Worker extends EventEmitter {
   resourceLimits: object;
   _handle: ReturnType<WorkerThreadForkFn> | null;
   _terminated: boolean;
-  _isReffed: boolean;
+  _elHandle: Handle | null;
   postMessage(value: unknown, _transferListOrOptions?: unknown): void;
   terminate(): Promise<number>;
   ref(): this;
@@ -157,7 +169,7 @@ export const Worker = function Worker(
   this.resourceLimits = {};
   this._handle = null;
   this._terminated = false;
-  this._isReffed = false;
+  this._elHandle = null;
 
   // if override is installed (napi-rs WASI worker factory), delegate — it handles both WASI workers and fork-based fallback
   if (_workerConstructorOverride) {
@@ -202,10 +214,8 @@ export const Worker = function Worker(
       self.emit("error", err);
     },
     onExit: (code: number) => {
-      if (self._isReffed) {
-        self._isReffed = false;
-        eventLoopUnref();
-      }
+      self._elHandle?.close();
+      self._elHandle = null;
       self._terminated = true;
       self.emit("exit", code);
     },
@@ -221,9 +231,8 @@ export const Worker = function Worker(
 
   this._handle = handle;
 
-  // keep parent alive while worker runs (Node.js default)
-  this._isReffed = true;
-  eventLoopRef();
+  // workers are refed by default in node, keeps parent alive
+  this._elHandle = getRegistry().register("Worker");
 
   queueMicrotask(() => {
     if (!self._terminated) self.emit("online");
@@ -240,10 +249,8 @@ Worker.prototype.postMessage = function postMessage(this: any, value: unknown, _
 
 Worker.prototype.terminate = function terminate(this: any): Promise<number> {
   if (this._handle && !this._terminated) {
-    if (this._isReffed) {
-      this._isReffed = false;
-      eventLoopUnref();
-    }
+    this._elHandle?.close();
+    this._elHandle = null;
     this._terminated = true;
     this._handle.terminate();
   }
@@ -251,18 +258,12 @@ Worker.prototype.terminate = function terminate(this: any): Promise<number> {
 };
 
 Worker.prototype.ref = function ref(this: any): any {
-  if (!this._isReffed && !this._terminated) {
-    this._isReffed = true;
-    eventLoopRef();
-  }
+  if (!this._terminated) (this._elHandle as Handle | null)?.ref();
   return this;
 };
 
 Worker.prototype.unref = function unref(this: any): any {
-  if (this._isReffed) {
-    this._isReffed = false;
-    eventLoopUnref();
-  }
+  (this._elHandle as Handle | null)?.unref();
   return this;
 };
 
@@ -329,14 +330,22 @@ export const BroadcastChannel = function BroadcastChannel(this: any, label: stri
   if (!this) return;
   EventEmitter.call(this);
   this.name = label;
+  this._elHandle = getRegistry().register("BroadcastChannel");
 } as unknown as BroadcastChannelConstructor;
 
 Object.setPrototypeOf(BroadcastChannel.prototype, EventEmitter.prototype);
 
 BroadcastChannel.prototype.postMessage = function postMessage(_msg: unknown): void {};
-BroadcastChannel.prototype.close = function close(): void {};
-BroadcastChannel.prototype.ref = function ref(): void {};
-BroadcastChannel.prototype.unref = function unref(): void {};
+BroadcastChannel.prototype.close = function close(this: any): void {
+  (this._elHandle as Handle | null)?.close();
+  this._elHandle = null;
+};
+BroadcastChannel.prototype.ref = function ref(this: any): void {
+  (this._elHandle as Handle | null)?.ref();
+};
+BroadcastChannel.prototype.unref = function unref(this: any): void {
+  (this._elHandle as Handle | null)?.unref();
+};
 
 
 export function moveMessagePortToContext(

--- a/src/polyfills/ws.ts
+++ b/src/polyfills/ws.ts
@@ -5,6 +5,7 @@ import { encodeFrame, decodeFrame } from "./http";
 import { Buffer } from "./buffer";
 import { createHash } from "./crypto";
 import type { TcpSocket } from "./net";
+import { getRegistry, type Handle } from "../helpers/event-loop";
 
 // polyfill for environments missing CloseEvent / MessageEvent
 const SafeCloseEvent: typeof CloseEvent =
@@ -102,6 +103,7 @@ export interface WebSocket extends TinyEmitter {
   _native: globalThis.WebSocket | null;
   _tcpSocket: TcpSocket | null;
   _tcpInboundBuf: Uint8Array;
+  _elHandle: Handle | null;
   onopen: ((ev: Event) => void) | null;
   onclose: ((ev: CloseEvent) => void) | null;
   onerror: ((ev: Event) => void) | null;
@@ -113,6 +115,8 @@ export interface WebSocket extends TinyEmitter {
   ping(): void;
   pong(): void;
   terminate(): void;
+  ref(): this;
+  unref(): this;
   _bindServer(srv: WebSocketServer): void;
   _deliverMessage(data: unknown): void;
 }
@@ -149,6 +153,8 @@ export const WebSocket = function WebSocket(this: any, address: string, protocol
   this.onclose = null;
   this.onerror = null;
   this.onmessage = null;
+  // keeps the loop alive while the socket is open. released in close/terminate.
+  this._elHandle = getRegistry().register("WebSocket");
   if (protocols) this.protocol = Array.isArray(protocols) ? protocols[0] : protocols;
   const self = this;
   setTimeout(() => self._open(), 0);
@@ -208,6 +214,8 @@ WebSocket.prototype._open = function _open(this: any): void {
       const ce = new SafeCloseEvent('close', { code: d.code || 1000, reason: d.reason || '', wasClean: true });
       self.emit('close', ce);
       self.onclose?.(ce);
+      (self._elHandle as Handle | null)?.close();
+      self._elHandle = null;
       chan.removeEventListener('message', onMsg);
     } else if (d.kind === 'fault') {
       const ee = new Event('error');
@@ -273,6 +281,8 @@ WebSocket.prototype._openNative = function _openNative(this: any): void {
     const ce = new SafeCloseEvent('close', { code: raw.code, reason: raw.reason, wasClean: raw.wasClean });
     self.emit('close', ce);
     self.onclose?.(ce);
+    (self._elHandle as Handle | null)?.close();
+    self._elHandle = null;
   };
 
   this._native.onerror = () => {
@@ -318,7 +328,12 @@ WebSocket.prototype.close = function close(this: any, code?: number, reason?: st
   if (this.readyState === CLOSED || this.readyState === CLOSING) return;
   this.readyState = CLOSING;
 
-  if (this._native) { this._native.close(code, reason); return; }
+  const releaseHandle = () => {
+    (this._elHandle as Handle | null)?.close();
+    this._elHandle = null;
+  };
+
+  if (this._native) { this._native.close(code, reason); releaseHandle(); return; }
 
   // TcpSocket-backed — send close frame
   if (this._tcpSocket) {
@@ -335,6 +350,7 @@ WebSocket.prototype.close = function close(this: any, code?: number, reason?: st
       self.emit('close', ce);
       self.onclose?.(ce);
       self._tcpSocket = null;
+      releaseHandle();
     }, 0);
     return;
   }
@@ -349,6 +365,7 @@ WebSocket.prototype.close = function close(this: any, code?: number, reason?: st
     const ce = new SafeCloseEvent('close', { code: code || 1000, reason: reason || '', wasClean: true });
     self.emit('close', ce);
     self.onclose?.(ce);
+    releaseHandle();
   }, 0);
 };
 
@@ -359,9 +376,21 @@ WebSocket.prototype.terminate = function terminate(this: any): void {
   if (this._native) { this._native.close(); this._native = null; }
   if (this._tcpSocket) { try { this._tcpSocket.destroy(); } catch { /* */ } this._tcpSocket = null; }
   this.readyState = CLOSED;
+  (this._elHandle as Handle | null)?.close();
+  this._elHandle = null;
   const ce = new SafeCloseEvent('close', { code: 1006, reason: 'Terminated', wasClean: false });
   this.emit('close', ce);
   this.onclose?.(ce);
+};
+
+WebSocket.prototype.ref = function ref(this: any): any {
+  (this._elHandle as Handle | null)?.ref();
+  return this;
+};
+
+WebSocket.prototype.unref = function unref(this: any): any {
+  (this._elHandle as Handle | null)?.unref();
+  return this;
 };
 
 WebSocket.prototype._bindServer = function _bindServer(this: any, srv: WebSocketServer): void { this._boundServer = srv; };
@@ -570,7 +599,7 @@ WebSocketServer.prototype.handleUpgrade = function handleUpgrade(
   }, 0);
 };
 
-WebSocketServer.prototype.close = function close(this: any, done?: () => void): void {
+WebSocketServer.prototype.close = function close(this: any, done?: (err?: Error) => void): void {
   for (const c of this.clients) c.close(1001, 'Server closing');
   this.clients.clear();
   activeServers.delete(this._route);

--- a/src/script-engine.ts
+++ b/src/script-engine.ts
@@ -127,6 +127,7 @@ import {
   precompileWasm,
   compileWasmInWorker,
 } from "./helpers/wasm-cache";
+import { getRegistry } from "./helpers/event-loop";
 import * as acorn from "acorn";
 
 // ── TypeScript type stripper ──
@@ -2126,83 +2127,89 @@ export class ScriptEngine {
     // Intercept fetch() for file:// URLs — serve from VFS instead of network.
     // napi-rs wasm32-wasi packages use fetch(new URL('file.wasm', import.meta.url))
     // which browsers block. This patches fetch to read from the in-memory filesystem.
+    // every fetch also registers a FetchRequest Handle so the loop stays
+    // alive until the request settles. matches node's undici.
     if (!(globalThis.fetch as any).__nodepodPatched) {
       const origFetch = globalThis.fetch.bind(globalThis);
       const patchedFetch = (
         input: RequestInfo | URL,
         init?: RequestInit,
       ): Promise<Response> => {
-        let url: string | undefined;
-        if (typeof input === "string") url = input;
-        else if (input instanceof URL) url = input.href;
-        else if (input instanceof Request) url = input.url;
+        const handle = getRegistry().register("FetchRequest");
+        const doFetch = (): Promise<Response> => {
+          let url: string | undefined;
+          if (typeof input === "string") url = input;
+          else if (input instanceof URL) url = input.href;
+          else if (input instanceof Request) url = input.url;
 
-        if (url?.startsWith("file://")) {
-          // Convert file:// URL to VFS path
-          let vfsPath: string;
-          try {
-            vfsPath = decodeURIComponent(new URL(url).pathname);
-          } catch {
-            vfsPath = decodeURIComponent(url.slice(7));
-          }
-          const v = (globalThis as any).__nodepodVolume as
-            | MemoryVolume
-            | undefined;
-          if (v) {
+          if (url?.startsWith("file://")) {
+            // Convert file:// URL to VFS path
+            let vfsPath: string;
             try {
-              const data = v.readFileSync(vfsPath);
-              const bytes =
-                data instanceof Uint8Array
-                  ? data
-                  : new TextEncoder().encode(String(data));
-              const contentType = vfsPath.endsWith(".wasm")
-                ? "application/wasm"
-                : "application/octet-stream";
-              return Promise.resolve(
-                new Response(
-                  bytes.buffer.slice(
-                    bytes.byteOffset,
-                    bytes.byteOffset + bytes.byteLength,
-                  ) as ArrayBuffer,
-                  {
-                    status: 200,
-                    headers: { "Content-Type": contentType },
-                  },
-                ),
-              );
+              vfsPath = decodeURIComponent(new URL(url).pathname);
             } catch {
-              // .wasm files under node_modules that aren't in the VFS (big binaries that failed extraction) — fetch from CDN
-              if (vfsPath.endsWith(".wasm") && vfsPath.includes("/node_modules/")) {
-                const nmIdx = vfsPath.lastIndexOf("/node_modules/");
-                const afterNm = vfsPath.substring(nmIdx + "/node_modules/".length);
-                // afterNm looks like "lightningcss-wasm/lightningcss_node.wasm" or "@scope/pkg/file.wasm"
-                const parts = afterNm.split("/");
-                let pkgName: string;
-                let filePath: string;
-                if (parts[0].startsWith("@")) {
-                  pkgName = parts[0] + "/" + parts[1];
-                  filePath = parts.slice(2).join("/");
-                } else {
-                  pkgName = parts[0];
-                  filePath = parts.slice(1).join("/");
+              vfsPath = decodeURIComponent(url.slice(7));
+            }
+            const v = (globalThis as any).__nodepodVolume as
+              | MemoryVolume
+              | undefined;
+            if (v) {
+              try {
+                const data = v.readFileSync(vfsPath);
+                const bytes =
+                  data instanceof Uint8Array
+                    ? data
+                    : new TextEncoder().encode(String(data));
+                const contentType = vfsPath.endsWith(".wasm")
+                  ? "application/wasm"
+                  : "application/octet-stream";
+                return Promise.resolve(
+                  new Response(
+                    bytes.buffer.slice(
+                      bytes.byteOffset,
+                      bytes.byteOffset + bytes.byteLength,
+                    ) as ArrayBuffer,
+                    {
+                      status: 200,
+                      headers: { "Content-Type": contentType },
+                    },
+                  ),
+                );
+              } catch {
+                // .wasm under node_modules that aren't in the VFS (big binaries that didn't extract), pull from CDN
+                if (vfsPath.endsWith(".wasm") && vfsPath.includes("/node_modules/")) {
+                  const nmIdx = vfsPath.lastIndexOf("/node_modules/");
+                  const afterNm = vfsPath.substring(nmIdx + "/node_modules/".length);
+                  // afterNm looks like "lightningcss-wasm/lightningcss_node.wasm" or "@scope/pkg/file.wasm"
+                  const parts = afterNm.split("/");
+                  let pkgName: string;
+                  let filePath: string;
+                  if (parts[0].startsWith("@")) {
+                    pkgName = parts[0] + "/" + parts[1];
+                    filePath = parts.slice(2).join("/");
+                  } else {
+                    pkgName = parts[0];
+                    filePath = parts.slice(1).join("/");
+                  }
+                  // grab version from package.json if present
+                  let version = "latest";
+                  try {
+                    const pkgJsonPath = vfsPath.substring(0, nmIdx + "/node_modules/".length) + pkgName + "/package.json";
+                    const pkgJson = JSON.parse(v.readFileSync(pkgJsonPath, "utf8"));
+                    if (pkgJson.version) version = pkgJson.version;
+                  } catch { /* use latest */ }
+                  const cdnUrl = `https://cdn.jsdelivr.net/npm/${pkgName}@${version}/${filePath}`;
+                  return origFetch(cdnUrl);
                 }
-                // grab version from package.json if present
-                let version = "latest";
-                try {
-                  const pkgJsonPath = vfsPath.substring(0, nmIdx + "/node_modules/".length) + pkgName + "/package.json";
-                  const pkgJson = JSON.parse(v.readFileSync(pkgJsonPath, "utf8"));
-                  if (pkgJson.version) version = pkgJson.version;
-                } catch { /* use latest */ }
-                const cdnUrl = `https://cdn.jsdelivr.net/npm/${pkgName}@${version}/${filePath}`;
-                return origFetch(cdnUrl);
+                return Promise.resolve(
+                  new Response("Not found", { status: 404 }),
+                );
               }
-              return Promise.resolve(
-                new Response("Not found", { status: 404 }),
-              );
             }
           }
-        }
-        return origFetch(input, init);
+          return origFetch(input, init);
+        };
+        return doFetch().finally(() => handle.close());
       };
       (globalThis as any).fetch = Object.assign(patchedFetch, {
         __nodepodPatched: true,
@@ -2286,73 +2293,19 @@ export class ScriptEngine {
       (globalThis as any).WebAssembly.Module = PatchedModule;
     }
 
-    // Timers need .ref()/.unref() to match Node.js API
+    // timers need .ref/.unref to match node's API and have to register
+    // Handles so the loop knows about pending work. delegate to the
+    // node:timers polyfill, it wires everything through getRegistry().
     if (!(globalThis.setTimeout as any).__nodepodPatched) {
-      const origST = globalThis.setTimeout.bind(globalThis);
-      const origSI = globalThis.setInterval.bind(globalThis);
-      const origCT = globalThis.clearTimeout.bind(globalThis);
-      const origCI = globalThis.clearInterval.bind(globalThis);
-
-      const wrapTimeout = (id: ReturnType<typeof origST>) => {
-        const obj = {
-          _id: id,
-          _ref: true,
-          ref() {
-            obj._ref = true;
-            return obj;
-          },
-          unref() {
-            obj._ref = false;
-            return obj;
-          },
-          hasRef() {
-            return obj._ref;
-          },
-          refresh() {
-            return obj;
-          },
-          [Symbol.toPrimitive]() {
-            return id;
-          },
-        };
-        return obj;
-      };
-
-      const wrapInterval = (id: ReturnType<typeof origSI>) => {
-        const obj = {
-          _id: id,
-          _ref: true,
-          ref() {
-            obj._ref = true;
-            return obj;
-          },
-          unref() {
-            obj._ref = false;
-            return obj;
-          },
-          hasRef() {
-            return obj._ref;
-          },
-          refresh() {
-            return obj;
-          },
-          [Symbol.toPrimitive]() {
-            return id;
-          },
-        };
-        return obj;
-      };
-
-      (globalThis as any).setTimeout = Object.assign(
-        (...a: Parameters<typeof origST>) => wrapTimeout(origST(...a)),
-        { __nodepodPatched: true },
-      );
+      (globalThis as any).setTimeout = Object.assign(timersPolyfill.setTimeout, {
+        __nodepodPatched: true,
+      });
       (globalThis as any).setInterval = Object.assign(
-        (...a: Parameters<typeof origSI>) => wrapInterval(origSI(...a)),
+        timersPolyfill.setInterval,
         { __nodepodPatched: true },
       );
-      (globalThis as any).clearTimeout = (t: any) => origCT(t?._id ?? t);
-      (globalThis as any).clearInterval = (t: any) => origCI(t?._id ?? t);
+      (globalThis as any).clearTimeout = timersPolyfill.clearTimeout;
+      (globalThis as any).clearInterval = timersPolyfill.clearInterval;
     }
 
     this.patchStackTraceApi();

--- a/src/threading/process-context.ts
+++ b/src/threading/process-context.ts
@@ -3,6 +3,7 @@
 // One active context on main thread; each worker gets its own.
 
 import type { MemoryVolume } from "../memory-volume";
+import { createHandleRegistry, type HandleRegistry } from "../helpers/event-loop";
 
 // --- I/O interfaces ---
 
@@ -29,8 +30,8 @@ export interface ProcessContext {
 
   volume: MemoryVolume;
 
-  refCount: number;
-  drainListeners: Set<() => void>;
+  /** typed Handle registry, tracks live async primitives for loop liveness */
+  handles: HandleRegistry;
 
   termCols: (() => number) | null;
   termRows: (() => number) | null;
@@ -68,8 +69,7 @@ export function createProcessContext(opts: {
 
     volume: opts.volume,
 
-    refCount: 0,
-    drainListeners: new Set(),
+    handles: createHandleRegistry(),
 
     termCols: null,
     termRows: null,

--- a/src/threading/process-manager.ts
+++ b/src/threading/process-manager.ts
@@ -34,6 +34,9 @@ export class ProcessManager extends EventEmitter {
   private _serverPorts = new Map<number, number>();
   // parent pid → child pids, used for exit deferral
   private _childPids = new Map<number, Set<number>>();
+  // pids of children that inherit their parent's stdin. stdin-forward only
+  // routes to pids in this set. stdio:'pipe' kids get their own isolated stdin.
+  private _inheritStdinChildren = new Set<number>();
   private _httpCallbacks = new Map<number, (resp: WorkerToMain_HttpResponse) => void>();
   private _nextHttpRequestId = 1;
 
@@ -307,11 +310,13 @@ export class ProcessManager extends EventEmitter {
       this._killDescendants(handle.pid, signal);
     });
 
-    // forward stdin to children even when parent is blocked on Atomics.wait
+    // forward stdin to children even when parent is blocked on Atomics.wait.
+    // only routes to stdio:'inherit' children; stdio:'pipe' kids are isolated.
     handle.on("stdin-forward", (data: string) => {
       const children = this._childPids.get(handle.pid);
       if (children) {
         for (const childPid of children) {
+          if (!this._inheritStdinChildren.has(childPid)) continue;
           const childHandle = this._processes.get(childPid);
           if (childHandle && childHandle.state !== "exited") {
             childHandle.sendStdin(data);
@@ -423,6 +428,12 @@ export class ProcessManager extends EventEmitter {
         }
         this._childPids.get(handle.pid)!.add(childHandle.pid);
 
+        // remember stdio:inherit so stdin-forward routes parent's stdin here.
+        // msg.stdio can be the legacy string or node's [stdin, stdout, stderr].
+        const inheritsStdin = msg.stdio === "inherit"
+          || (Array.isArray(msg.stdio) && msg.stdio[0] === "inherit");
+        if (inheritsStdin) this._inheritStdinChildren.add(childHandle.pid);
+
         // defer parent exit/done until child finishes (e.g. create-vite -> vite dev)
         handle.holdExit();
         handle.holdShellDone();
@@ -509,6 +520,7 @@ export class ProcessManager extends EventEmitter {
             children.delete(childHandle.pid);
             if (children.size === 0) this._childPids.delete(handle.pid);
           }
+          this._inheritStdinChildren.delete(childHandle.pid);
           handle.releaseExit();
           handle.releaseShellDone();
         });
@@ -625,6 +637,7 @@ export class ProcessManager extends EventEmitter {
             children.delete(childHandle.pid);
             if (children.size === 0) this._childPids.delete(handle.pid);
           }
+          this._inheritStdinChildren.delete(childHandle.pid);
           handle.releaseExit();
           handle.releaseShellDone();
         });
@@ -764,6 +777,7 @@ export class ProcessManager extends EventEmitter {
             children.delete(childHandle.pid);
             if (children.size === 0) this._childPids.delete(handle.pid);
           }
+          this._inheritStdinChildren.delete(childHandle.pid);
           handle.releaseExit();
           handle.releaseShellDone();
         });
@@ -813,6 +827,12 @@ export class ProcessManager extends EventEmitter {
           this._childPids.set(handle.pid, new Set());
         }
         this._childPids.get(handle.pid)!.add(childHandle.pid);
+
+        // spawnSync defaults to 'inherit' when stdio is omitted (matches node,
+        // since it's usually used for interactive children like npm install
+        // under create-vite).
+        const stdinInherits = !msg.stdio || msg.stdio[0] === "inherit";
+        if (stdinInherits) this._inheritStdinChildren.add(childHandle.pid);
 
         handle.holdExit();
         handle.holdShellDone();
@@ -875,6 +895,7 @@ export class ProcessManager extends EventEmitter {
             children.delete(childHandle.pid);
             if (children.size === 0) this._childPids.delete(handle.pid);
           }
+          this._inheritStdinChildren.delete(childHandle.pid);
 
           handle.releaseSync();
           handle.releaseExit();
@@ -888,6 +909,7 @@ export class ProcessManager extends EventEmitter {
             children.delete(childHandle.pid);
             if (children.size === 0) this._childPids.delete(handle.pid);
           }
+          this._inheritStdinChildren.delete(childHandle.pid);
           handle.releaseSync();
           handle.releaseExit();
           handle.releaseShellDone();

--- a/src/threading/process-worker-entry.ts
+++ b/src/threading/process-worker-entry.ts
@@ -789,7 +789,7 @@ export function spawnChild(
   opts?: {
     cwd?: string;
     env?: Record<string, string>;
-    stdio?: "pipe" | "inherit";
+    stdio?: "pipe" | "inherit" | Array<"pipe" | "inherit" | "ignore">;
     onStdout?: (data: string) => void;
     onStderr?: (data: string) => void;
   },

--- a/src/threading/worker-protocol.ts
+++ b/src/threading/worker-protocol.ts
@@ -205,7 +205,9 @@ export interface WorkerToMain_SpawnRequest {
   args: string[];
   cwd: string;
   env: Record<string, string>;
-  stdio: "pipe" | "inherit";
+  // legacy single-string form or node's [stdin, stdout, stderr] array.
+  // main normalizes either shape via stdioInheritsStdin().
+  stdio: "pipe" | "inherit" | Array<"pipe" | "inherit" | "ignore">;
 }
 
 export interface WorkerToMain_ForkRequest {
@@ -238,6 +240,8 @@ export interface WorkerToMain_SpawnSync {
   env: Record<string, string>;
   syncSlot: number; // index in the sync SAB for Atomics.wait/notify
   shellCommand?: string;
+  // optional node-shape array, defaults to ["pipe","pipe","pipe"] if absent
+  stdio?: Array<"pipe" | "inherit" | "ignore">;
 }
 
 export interface WorkerToMain_ServerListen {


### PR DESCRIPTION
## what
adds a typed handle registry so async stuff (timers, fs.watch, net sockets, workers, fetch, readline, ws, dgram, http, http2, child_process) gets tracked the way libuv tracks handles. the registry has a refcount, a drain promise that fires when the count hits zero, and a beforeExit hook.

the script engine now waits on `drainPromise()` after top-level await settles, then emits `beforeExit` before actually exiting. this matches how node behaves.

## why
before this, nodepod would exit as soon as top-level await resolved. even if there was a pending setTimeout, an open fs.watch, or a running worker, it just bailed out.

that broke a bunch of real-world tools:
- vite's q+Enter shutdown flow
- create-qwik style async CLI prompts
- anything using chokidar, @clack, readline, or a long-lived fetch

basically anything that assumed the node event loop keeps the process alive until handles close.

## what changed
- `src/helpers/event-loop.ts` is new. it has the `HandleRegistry` with O(1) refed count, a drain promise that re-arms, sequential beforeExit handlers, and a `closeAll` for forced shutdown.
- `src/script-engine.ts` wait loop does drain -> beforeExit -> maybe-exit instead of exiting straight away.
- all the polyfills now register a handle when they create an async resource, and close/unref it on the right lifecycle events. that covers timers, fs, net, http, http2, ws, worker_threads, child_process, readline, dgram, fetch.
- added `process.getActiveResourcesInfo()` which returns handles grouped by type. useful for debugging.
- `process.exit()` now unwinds via a sentinel so it bypasses drain and exits right away.
- two new test files: `event-loop.test.ts` for the registry itself, `exit-semantics.test.ts` for the real world patterns.

## risk
every async primitive now goes through the registry. if the refcount is wrong somewhere it'll either leak a handle (hang forever) or drop one too early (exit too soon). idempotency tests cover the obvious cases and `closeAll` on `process.exit` is a safety net.

behavior change: scripts that used to exit immediately on TLA settle now wait for pending handles. this is the whole point of the change but worth flagging.

## test plan
- [x] `npm test` passes (510 tests)
- [x] registry unit tests in `event-loop.test.ts` cover ref counting, idempotent close, drain re-arming, beforeExit order and error swallowing
- [x] real world regressions in `exit-semantics.test.ts` cover create-qwik flow, fs.watch close, readline cleanup, EventEmitter async listener
- [x] manual: top-level `setTimeout(() => {}, 1000)` waits ~1s before exiting
- [x] manual: script with `fs.watch(...)` does not exit until watcher is closed
- [x] manual: `process.exit(1)` exits right away with code 1
- [x] manual: `beforeExit` fires with the right code and can schedule more work that keeps the loop alive
- [x] manual: run `npx create-vite` / `npx create-qwik` inside nodepod, prompt flow finishes without hanging or early exit
