### PR TITLE
feat(sdk): add Nodepod.attachFS for sibling-worker VFS access

### DIFF
--- a/examples/serve.js
+++ b/examples/serve.js
@@ -51,4 +51,5 @@ createServer((req, res) => {
   console.log(`  Native WASI test:     http://localhost:${port}/examples/native-wasi-test/`);
   console.log(`  SW setup DX:          http://localhost:${port}/examples/sw-setup/`);
   console.log(`  Terminal resize:      http://localhost:${port}/examples/terminal-resize/`);
+  console.log(`  Shared FS attach:     http://localhost:${port}/examples/shared-fs-attach/`);
 });

--- a/examples/shared-fs-attach/index.html
+++ b/examples/shared-fs-attach/index.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>nodepod - shared FS attach from sibling worker</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: monospace; background: #1a1a2e; color: #e0e0e0; padding: 24px; }
+    h1 { font-size: 18px; margin-bottom: 8px; color: #fff; }
+    p { font-size: 13px; color: #888; margin-bottom: 20px; max-width: 800px; line-height: 1.5; }
+    #output {
+      background: #0d0d1a;
+      border: 1px solid #333;
+      border-radius: 6px;
+      padding: 16px;
+      min-height: 400px;
+      white-space: pre-wrap;
+      font-size: 14px;
+      line-height: 1.6;
+      overflow-y: auto;
+    }
+    .stdout { color: #a8e6a3; }
+    .stderr { color: #e68a8a; }
+    .info   { color: #8ac4e6; }
+    .dim    { color: #555; }
+    .pass   { color: #a8e6a3; }
+    .fail   { color: #e68a8a; font-weight: bold; }
+    .main   { color: #e6c38a; }
+    .sib    { color: #c48ae6; }
+  </style>
+</head>
+<body>
+  <h1>nodepod - shared FS attach from sibling worker</h1>
+  <p>
+    Demo of <code>Nodepod.attachFS(sab)</code>. Main thread boots nodepod, creates a plain
+    <em>sibling</em> Web Worker (not one nodepod spawned via <code>spawn()</code>), and
+    postMessages it the shared VFS buffer. The sibling reads files straight out of the same
+    SharedArrayBuffer, no IPC per call. When main writes a new file the sibling sees it on the
+    next read because they're looking at the same memory. [gold = main, purple = sibling]
+  </p>
+  <div id="output"></div>
+
+  <script type="module">
+    import { Nodepod } from "/dist/index.mjs";
+
+    const out = document.getElementById('output');
+    function log(text, cls = 'stdout') {
+      const span = document.createElement('span');
+      span.className = cls;
+      span.textContent = text + '\n';
+      out.appendChild(span);
+      out.scrollTop = out.scrollHeight;
+    }
+
+    log('[main] Booting nodepod...', 'main');
+
+    const nodepod = await Nodepod.boot({
+      files: {
+        '/hello.txt': 'hello from the main thread',
+        '/proj/package.json': JSON.stringify({ name: 'demo', version: '1.0.0' }, null, 2),
+        '/proj/src/index.js': '// sibling worker reads this one direct from SAB\nmodule.exports = 42;',
+        '/proj/src/util.js': 'module.exports = { add: (a, b) => a + b };',
+        '/proj/README.md': '# demo project\n\nused in the shared-fs-attach example',
+      },
+      serviceWorker: false, // not needed for this demo
+    });
+
+    log('[main] Booted. SAB size: ' + nodepod.sharedFSBuffer?.byteLength + ' bytes', 'main');
+    log('', 'dim');
+
+    // sibling runs outside nodepod's process manager
+    const sibling = new Worker('/examples/shared-fs-attach/sibling-worker.js', { type: 'module' });
+
+    sibling.addEventListener('message', (ev) => {
+      const { type, text, cls } = ev.data;
+      if (type === 'log') {
+        log('[sibling] ' + text, cls || 'sib');
+      }
+    });
+
+    // the whole attach handshake, one postMessage
+    log('[main] postMessage sharedFSBuffer to sibling...', 'main');
+    sibling.postMessage({ type: 'attach', buffer: nodepod.sharedFSBuffer });
+
+    await new Promise((r) => setTimeout(r, 600));
+
+    log('[main] Writing /live.txt via nodepod.fs ...', 'main');
+    await nodepod.fs.writeFile('/live.txt', 'written after sibling attached');
+    sibling.postMessage({ type: 'reread', path: '/live.txt' });
+
+    await new Promise((r) => setTimeout(r, 400));
+    log('', 'dim');
+    log('[main] Trying a write from the sibling (should throw ENOTSUP)...', 'main');
+    sibling.postMessage({ type: 'try-write' });
+
+    await new Promise((r) => setTimeout(r, 400));
+    log('', 'dim');
+    log('[main] Demo complete.', 'info');
+  </script>
+</body>
+</html>

--- a/examples/shared-fs-attach/sibling-worker.js
+++ b/examples/shared-fs-attach/sibling-worker.js
@@ -1,0 +1,75 @@
+// sibling worker for the attach example. not spawned by nodepod, just a
+// plain new Worker() on the page. it uses Nodepod.attachFS(sab) to read
+// straight from the same SharedArrayBuffer the main thread's nodepod owns.
+
+import { Nodepod } from "/dist/index.mjs";
+
+let fs = null;
+
+function send(text, cls) {
+  self.postMessage({ type: "log", text, cls });
+}
+
+// silent promise rejections make attach failures look like the worker
+// just went quiet, surface them instead
+self.addEventListener("unhandledrejection", (ev) => {
+  send("unhandledrejection: " + (ev.reason?.stack || ev.reason), "fail");
+});
+
+self.addEventListener("message", async (ev) => {
+  const msg = ev.data;
+  try {
+    if (msg.type === "attach") {
+      send("received SharedArrayBuffer, calling Nodepod.attachFS()");
+      fs = Nodepod.attachFS(msg.buffer);
+      send("attached. version=" + fs.version);
+
+      send("fs.exists('/hello.txt') => " + (await fs.exists("/hello.txt")));
+
+      const greeting = await fs.readFile("/hello.txt", "utf8");
+      send("fs.readFile('/hello.txt', 'utf8') => " + JSON.stringify(greeting));
+
+      const bytes = await fs.readFile("/proj/src/index.js");
+      send("fs.readFile('/proj/src/index.js') => Uint8Array(" + bytes.byteLength + ")");
+
+      const stat = await fs.stat("/proj/package.json");
+      send("fs.stat('/proj/package.json') => " + JSON.stringify(stat));
+
+      const entries = await fs.readdir("/proj/src");
+      send("fs.readdir('/proj/src') => " + JSON.stringify(entries.sort()));
+
+      try {
+        await fs.readFile("/nope.txt");
+      } catch (e) {
+        send("readFile missing => " + e.code + ": " + e.message, "dim");
+      }
+
+      send("current version (pre-write) = " + fs.version);
+    }
+
+    if (msg.type === "reread") {
+      const v = fs.version;
+      const exists = await fs.exists(msg.path);
+      if (exists) {
+        const text = await fs.readFile(msg.path, "utf8");
+        send("after main wrote " + msg.path + " (version=" + v + "): " + JSON.stringify(text), "pass");
+      } else {
+        send("expected to see " + msg.path + " but it was missing", "fail");
+      }
+    }
+
+    if (msg.type === "try-write") {
+      try {
+        await fs.writeFile("/attempt.txt", "nope");
+        send("writeFile returned without throwing, UNEXPECTED", "fail");
+      } catch (e) {
+        send(
+          "fs.writeFile threw " + e.code + " as expected (client is read-only)",
+          "pass",
+        );
+      }
+    }
+  } catch (e) {
+    send("handler error: " + (e?.stack || e), "fail");
+  }
+});

--- a/src/__tests__/shared-vfs.test.ts
+++ b/src/__tests__/shared-vfs.test.ts
@@ -1,0 +1,480 @@
+import { describe, it, expect } from "vitest";
+import { Worker } from "node:worker_threads";
+import {
+  SharedVFSController,
+  SharedVFSReader,
+  isSharedArrayBufferAvailable,
+} from "../threading/shared-vfs";
+import { NodepodFSClient, NodepodFSClientError } from "../sdk/nodepod-fs-client";
+import { MemoryVolume } from "../memory-volume";
+import { VFSBridge } from "../threading/vfs-bridge";
+
+describe("isSharedArrayBufferAvailable", () => {
+  it("returns true in Node 20+ test env", () => {
+    expect(isSharedArrayBufferAvailable()).toBe(true);
+  });
+});
+
+describe("SharedVFSController + SharedVFSReader", () => {
+  describe("readFileSync / writeFile roundtrip", () => {
+    it("reads back exact bytes written", () => {
+      const ctrl = new SharedVFSController();
+      const reader = new SharedVFSReader(ctrl.buffer);
+      const data = new Uint8Array([1, 2, 3, 4, 255]);
+
+      expect(ctrl.writeFile("/bin.dat", data)).toBe(true);
+      const out = reader.readFileSync("/bin.dat");
+
+      expect(out).toBeInstanceOf(Uint8Array);
+      expect(Array.from(out!)).toEqual([1, 2, 3, 4, 255]);
+    });
+
+    it("returns null for missing file", () => {
+      const ctrl = new SharedVFSController();
+      const reader = new SharedVFSReader(ctrl.buffer);
+      expect(reader.readFileSync("/nope.txt")).toBeNull();
+    });
+
+    it("returns null when reading a directory", () => {
+      const ctrl = new SharedVFSController();
+      const reader = new SharedVFSReader(ctrl.buffer);
+      ctrl.writeDirectory("/mydir");
+      expect(reader.readFileSync("/mydir")).toBeNull();
+    });
+
+    it("readFileSync result is an independent copy (mutation-safe)", () => {
+      const ctrl = new SharedVFSController();
+      const reader = new SharedVFSReader(ctrl.buffer);
+      ctrl.writeFile("/safe.dat", new Uint8Array([10, 20, 30]));
+
+      const first = reader.readFileSync("/safe.dat")!;
+      first[0] = 99;
+
+      const second = reader.readFileSync("/safe.dat")!;
+      expect(second[0]).toBe(10);
+    });
+
+    it("overwrites existing file (append-only storage, but path still resolves to latest)", () => {
+      const ctrl = new SharedVFSController();
+      const reader = new SharedVFSReader(ctrl.buffer);
+
+      ctrl.writeFile("/f.txt", new TextEncoder().encode("first"));
+      ctrl.writeFile("/f.txt", new TextEncoder().encode("second-longer"));
+
+      const out = reader.readFileSync("/f.txt")!;
+      expect(new TextDecoder().decode(out)).toBe("second-longer");
+    });
+  });
+
+  describe("existsSync / isDirectorySync", () => {
+    it("existsSync returns true for files and dirs, false for missing", () => {
+      const ctrl = new SharedVFSController();
+      const reader = new SharedVFSReader(ctrl.buffer);
+      ctrl.writeFile("/a.txt", new Uint8Array([1]));
+      ctrl.writeDirectory("/dir");
+
+      expect(reader.existsSync("/a.txt")).toBe(true);
+      expect(reader.existsSync("/dir")).toBe(true);
+      expect(reader.existsSync("/gone")).toBe(false);
+    });
+
+    it("isDirectorySync distinguishes dirs from files", () => {
+      const ctrl = new SharedVFSController();
+      const reader = new SharedVFSReader(ctrl.buffer);
+      ctrl.writeFile("/file", new Uint8Array([1]));
+      ctrl.writeDirectory("/dir");
+
+      expect(reader.isDirectorySync("/dir")).toBe(true);
+      expect(reader.isDirectorySync("/file")).toBe(false);
+      expect(reader.isDirectorySync("/missing")).toBe(false);
+    });
+  });
+
+  describe("statSync", () => {
+    it("returns file stat with correct size", () => {
+      const ctrl = new SharedVFSController();
+      const reader = new SharedVFSReader(ctrl.buffer);
+      const content = new TextEncoder().encode("hello world");
+      ctrl.writeFile("/hello.txt", content);
+
+      const stat = reader.statSync("/hello.txt")!;
+      expect(stat.isFile).toBe(true);
+      expect(stat.isDirectory).toBe(false);
+      expect(stat.size).toBe(content.byteLength);
+      expect(stat.mtime).toBeGreaterThan(0);
+    });
+
+    it("returns dir stat with size 0", () => {
+      const ctrl = new SharedVFSController();
+      const reader = new SharedVFSReader(ctrl.buffer);
+      ctrl.writeDirectory("/mydir");
+
+      const stat = reader.statSync("/mydir")!;
+      expect(stat.isFile).toBe(false);
+      expect(stat.isDirectory).toBe(true);
+      expect(stat.size).toBe(0);
+    });
+
+    it("returns null for missing path", () => {
+      const ctrl = new SharedVFSController();
+      const reader = new SharedVFSReader(ctrl.buffer);
+      expect(reader.statSync("/nope")).toBeNull();
+    });
+  });
+
+  describe("readdirSync", () => {
+    it("returns immediate children only (no nested paths)", () => {
+      const ctrl = new SharedVFSController();
+      const reader = new SharedVFSReader(ctrl.buffer);
+      ctrl.writeFile("/a.txt", new Uint8Array([1]));
+      ctrl.writeFile("/b.txt", new Uint8Array([1]));
+      ctrl.writeFile("/sub/nested.txt", new Uint8Array([1]));
+      ctrl.writeDirectory("/sub");
+      ctrl.writeDirectory("/other");
+
+      const root = reader.readdirSync("/");
+      expect(root.sort()).toEqual(["a.txt", "b.txt", "other", "sub"]);
+    });
+
+    it("returns nested children when given a subdir", () => {
+      const ctrl = new SharedVFSController();
+      const reader = new SharedVFSReader(ctrl.buffer);
+      ctrl.writeDirectory("/proj");
+      ctrl.writeFile("/proj/one.js", new Uint8Array([1]));
+      ctrl.writeFile("/proj/two.js", new Uint8Array([1]));
+      ctrl.writeFile("/proj/deep/nested.js", new Uint8Array([1]));
+
+      expect(reader.readdirSync("/proj").sort()).toEqual(["deep", "one.js", "two.js"]);
+    });
+
+    it("returns [] for missing directory", () => {
+      const ctrl = new SharedVFSController();
+      const reader = new SharedVFSReader(ctrl.buffer);
+      expect(reader.readdirSync("/does/not/exist")).toEqual([]);
+    });
+
+    it("does not include deleted entries", () => {
+      const ctrl = new SharedVFSController();
+      const reader = new SharedVFSReader(ctrl.buffer);
+      ctrl.writeFile("/a.txt", new Uint8Array([1]));
+      ctrl.writeFile("/b.txt", new Uint8Array([1]));
+      ctrl.deleteFile("/a.txt");
+
+      expect(reader.readdirSync("/")).toEqual(["b.txt"]);
+    });
+
+    it("handles trailing slash on dir path", () => {
+      const ctrl = new SharedVFSController();
+      const reader = new SharedVFSReader(ctrl.buffer);
+      ctrl.writeFile("/x/y.txt", new Uint8Array([1]));
+      ctrl.writeDirectory("/x");
+
+      expect(reader.readdirSync("/x")).toEqual(["y.txt"]);
+      expect(reader.readdirSync("/x/")).toEqual(["y.txt"]);
+    });
+  });
+
+  describe("version counter", () => {
+    it("increments on every write", () => {
+      const ctrl = new SharedVFSController();
+      const reader = new SharedVFSReader(ctrl.buffer);
+      const v0 = reader.version;
+
+      ctrl.writeFile("/a", new Uint8Array([1]));
+      const v1 = reader.version;
+      expect(v1).toBeGreaterThan(v0);
+
+      ctrl.writeFile("/b", new Uint8Array([1]));
+      expect(reader.version).toBeGreaterThan(v1);
+    });
+
+    it("increments on delete", () => {
+      const ctrl = new SharedVFSController();
+      const reader = new SharedVFSReader(ctrl.buffer);
+      ctrl.writeFile("/a", new Uint8Array([1]));
+      const v = reader.version;
+      ctrl.deleteFile("/a");
+      expect(reader.version).toBeGreaterThan(v);
+    });
+  });
+
+  describe("caps", () => {
+    it("path over 248 bytes gets truncated, still writes", () => {
+      // path cap doesn't return false, it just truncates. documents the quirk.
+      const ctrl = new SharedVFSController();
+      const longPath = "/" + "a".repeat(300);
+      const res = ctrl.writeFile(longPath, new Uint8Array([1]));
+      expect(typeof res).toBe("boolean");
+    });
+
+    it("writeFile returns false when data won't fit", () => {
+      // need a buffer big enough for the fixed table (16+16384*264) plus a
+      // tiny bit of data, then try to overflow that tiny bit.
+      const HEADER_AND_TABLE = 16 + 16384 * 264;
+      const ctrl = new SharedVFSController(HEADER_AND_TABLE + 1024);
+
+      expect(ctrl.writeFile("/small.dat", new Uint8Array(500))).toBe(true);
+      expect(ctrl.writeFile("/big.dat", new Uint8Array(2000))).toBe(false);
+    });
+  });
+});
+
+describe("NodepodFSClient", () => {
+  it("readFile returns bytes", async () => {
+    const ctrl = new SharedVFSController();
+    ctrl.writeFile("/data.bin", new Uint8Array([9, 8, 7]));
+
+    const client = new NodepodFSClient(new SharedVFSReader(ctrl.buffer));
+    const bytes = await client.readFile("/data.bin");
+    expect(Array.from(bytes as Uint8Array)).toEqual([9, 8, 7]);
+  });
+
+  it("readFile with utf8 returns decoded string", async () => {
+    const ctrl = new SharedVFSController();
+    ctrl.writeFile("/hi.txt", new TextEncoder().encode("hello"));
+
+    const client = new NodepodFSClient(new SharedVFSReader(ctrl.buffer));
+    const text = await client.readFile("/hi.txt", "utf8");
+    expect(text).toBe("hello");
+  });
+
+  it("readFile throws ENOENT on missing file", async () => {
+    const ctrl = new SharedVFSController();
+    const client = new NodepodFSClient(new SharedVFSReader(ctrl.buffer));
+    await expect(client.readFile("/nope")).rejects.toMatchObject({
+      code: "ENOENT",
+      name: "NodepodFSClientError",
+    });
+  });
+
+  it("stat returns correct shape", async () => {
+    const ctrl = new SharedVFSController();
+    ctrl.writeFile("/a.txt", new TextEncoder().encode("abc"));
+    const client = new NodepodFSClient(new SharedVFSReader(ctrl.buffer));
+
+    const stat = await client.stat("/a.txt");
+    expect(stat.isFile).toBe(true);
+    expect(stat.isDirectory).toBe(false);
+    expect(stat.size).toBe(3);
+  });
+
+  it("stat throws ENOENT on missing path", async () => {
+    const ctrl = new SharedVFSController();
+    const client = new NodepodFSClient(new SharedVFSReader(ctrl.buffer));
+    await expect(client.stat("/nope")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("readdir returns children", async () => {
+    const ctrl = new SharedVFSController();
+    ctrl.writeDirectory("/proj");
+    ctrl.writeFile("/proj/a.js", new Uint8Array([1]));
+    ctrl.writeFile("/proj/b.js", new Uint8Array([1]));
+
+    const client = new NodepodFSClient(new SharedVFSReader(ctrl.buffer));
+    const entries = await client.readdir("/proj");
+    expect(entries.sort()).toEqual(["a.js", "b.js"]);
+  });
+
+  it("readdir throws ENOENT on missing non-root dir", async () => {
+    const ctrl = new SharedVFSController();
+    const client = new NodepodFSClient(new SharedVFSReader(ctrl.buffer));
+    await expect(client.readdir("/nope")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("exists reflects state", async () => {
+    const ctrl = new SharedVFSController();
+    ctrl.writeFile("/a", new Uint8Array([1]));
+    const client = new NodepodFSClient(new SharedVFSReader(ctrl.buffer));
+
+    expect(await client.exists("/a")).toBe(true);
+    expect(await client.exists("/b")).toBe(false);
+  });
+
+  describe("write operations throw ENOTSUP", () => {
+    const ctrl = new SharedVFSController();
+    const client = new NodepodFSClient(new SharedVFSReader(ctrl.buffer));
+
+    it("writeFile", async () => {
+      await expect(client.writeFile("/x", "y")).rejects.toMatchObject({ code: "ENOTSUP" });
+    });
+    it("mkdir", async () => {
+      await expect(client.mkdir("/x")).rejects.toMatchObject({ code: "ENOTSUP" });
+    });
+    it("unlink", async () => {
+      await expect(client.unlink("/x")).rejects.toMatchObject({ code: "ENOTSUP" });
+    });
+    it("rmdir", async () => {
+      await expect(client.rmdir("/x")).rejects.toMatchObject({ code: "ENOTSUP" });
+    });
+    it("rename", async () => {
+      await expect(client.rename("/x", "/y")).rejects.toMatchObject({ code: "ENOTSUP" });
+    });
+    it("appendFile", async () => {
+      await expect(client.appendFile("/x", "y")).rejects.toMatchObject({ code: "ENOTSUP" });
+    });
+
+    it("throws NodepodFSClientError (named)", async () => {
+      try {
+        await client.writeFile("/x", "y");
+        throw new Error("should have thrown");
+      } catch (e) {
+        expect(e).toBeInstanceOf(NodepodFSClientError);
+      }
+    });
+  });
+
+  it("version getter reflects reader version", async () => {
+    const ctrl = new SharedVFSController();
+    const client = new NodepodFSClient(new SharedVFSReader(ctrl.buffer));
+    const v0 = client.version;
+    ctrl.writeFile("/a", new Uint8Array([1]));
+    expect(client.version).toBeGreaterThan(v0);
+  });
+});
+
+describe("VFSBridge -> SharedVFS mirror (main-thread write visibility)", () => {
+  // regression: watch callbacks pass relative paths, bridge used to forward
+  // them as-is into SharedVFS so "/hello.txt" landed under "hello.txt" and
+  // sibling workers got ENOENT. bridge now promotes to absolute first.
+  it("stores entries under absolute paths so SharedVFSReader finds them", () => {
+    const vol = new MemoryVolume();
+    const ctrl = new SharedVFSController();
+    const bridge = new VFSBridge(vol);
+    bridge.setSharedVFS(ctrl);
+    const unwatch = bridge.watch();
+
+    vol.writeFileSync("/top.txt", "hi");
+    vol.mkdirSync("/proj", { recursive: true });
+    vol.mkdirSync("/proj/src", { recursive: true });
+    vol.writeFileSync("/proj/src/index.js", "module.exports = 1");
+
+    const reader = new SharedVFSReader(ctrl.buffer);
+    expect(reader.existsSync("/top.txt")).toBe(true);
+    expect(reader.existsSync("/proj")).toBe(true);
+    expect(reader.existsSync("/proj/src/index.js")).toBe(true);
+    expect(reader.isDirectorySync("/proj")).toBe(true);
+
+    const bytes = reader.readFileSync("/proj/src/index.js")!;
+    expect(new TextDecoder().decode(bytes)).toBe("module.exports = 1");
+
+    // the old buggy relative form must not be present
+    expect(reader.existsSync("top.txt")).toBe(false);
+    expect(reader.existsSync("proj/src/index.js")).toBe(false);
+
+    unwatch();
+  });
+
+  it("readdirSync on the reader sees bridge-mirrored dirs", () => {
+    const vol = new MemoryVolume();
+    const ctrl = new SharedVFSController();
+    const bridge = new VFSBridge(vol);
+    bridge.setSharedVFS(ctrl);
+    const unwatch = bridge.watch();
+
+    vol.mkdirSync("/app", { recursive: true });
+    vol.writeFileSync("/app/a.js", "a");
+    vol.writeFileSync("/app/b.js", "b");
+
+    const reader = new SharedVFSReader(ctrl.buffer);
+    expect(reader.readdirSync("/app").sort()).toEqual(["a.js", "b.js"]);
+
+    unwatch();
+  });
+
+  it("mirrors deletes as well as writes", () => {
+    const vol = new MemoryVolume();
+    const ctrl = new SharedVFSController();
+    const bridge = new VFSBridge(vol);
+    bridge.setSharedVFS(ctrl);
+    const unwatch = bridge.watch();
+
+    vol.writeFileSync("/gone.txt", "x");
+    const reader = new SharedVFSReader(ctrl.buffer);
+    expect(reader.existsSync("/gone.txt")).toBe(true);
+
+    vol.unlinkSync("/gone.txt");
+    expect(reader.existsSync("/gone.txt")).toBe(false);
+
+    unwatch();
+  });
+});
+
+describe("cross-thread attach (SAB via worker_threads)", () => {
+  it("a separate thread constructing a reader from the same SAB sees main-thread writes", async () => {
+    const ctrl = new SharedVFSController();
+    ctrl.writeFile("/greeting.txt", new TextEncoder().encode("hello from main"));
+    ctrl.writeFile("/data.bin", new Uint8Array([42, 43, 44]));
+    ctrl.writeDirectory("/proj");
+    ctrl.writeFile("/proj/one.js", new TextEncoder().encode("module.exports = 1"));
+
+    const workerSource = `
+      const { parentPort, workerData } = require("node:worker_threads");
+
+      // inline reader so the worker doesn't have to import the TS source.
+      // same shape as what a sibling worker would do in production.
+      const HEADER_SIZE = 16;
+      const ENTRY_SIZE = 264;
+      const ENTRY_FLAGS_OFFSET = 0;
+      const ENTRY_CONTENT_OFFSET = 4;
+      const ENTRY_CONTENT_LENGTH = 8;
+      const ENTRY_PATH_OFFSET = 16;
+      const ENTRY_PATH_MAX = 248;
+      const DATA_OFFSET = HEADER_SIZE + 16384 * ENTRY_SIZE;
+      const FLAG_ACTIVE = 1;
+
+      const buf = workerData.buffer;
+      const view = new DataView(buf);
+      const int32 = new Int32Array(buf);
+      const uint8 = new Uint8Array(buf);
+      const enc = new TextEncoder();
+      const dec = new TextDecoder();
+
+      function findEntry(path) {
+        const n = Atomics.load(int32, 1);
+        const bytes = enc.encode(path);
+        outer: for (let i = 0; i < n; i++) {
+          const off = HEADER_SIZE + i * ENTRY_SIZE;
+          const flags = view.getUint32(off + ENTRY_FLAGS_OFFSET);
+          if (!(flags & FLAG_ACTIVE)) continue;
+          for (let j = 0; j < bytes.length; j++) {
+            if (uint8[off + ENTRY_PATH_OFFSET + j] !== bytes[j]) continue outer;
+          }
+          if (uint8[off + ENTRY_PATH_OFFSET + bytes.length] === 0) return i;
+        }
+        return -1;
+      }
+
+      function readFile(path) {
+        const idx = findEntry(path);
+        if (idx === -1) return null;
+        const off = HEADER_SIZE + idx * ENTRY_SIZE;
+        const coff = view.getUint32(off + ENTRY_CONTENT_OFFSET);
+        const clen = view.getUint32(off + ENTRY_CONTENT_LENGTH);
+        return Array.from(uint8.subarray(DATA_OFFSET + coff, DATA_OFFSET + coff + clen));
+      }
+
+      parentPort.postMessage({
+        greeting: dec.decode(new Uint8Array(readFile("/greeting.txt"))),
+        dataBytes: readFile("/data.bin"),
+        projOneJs: dec.decode(new Uint8Array(readFile("/proj/one.js"))),
+        missing: readFile("/nope"),
+      });
+    `;
+
+    const worker = new Worker(workerSource, {
+      eval: true,
+      workerData: { buffer: ctrl.buffer },
+    });
+
+    const result: any = await new Promise((resolve, reject) => {
+      worker.once("message", resolve);
+      worker.once("error", reject);
+    });
+    await worker.terminate();
+
+    expect(result.greeting).toBe("hello from main");
+    expect(result.dataBytes).toEqual([42, 43, 44]);
+    expect(result.projOneJs).toBe("module.exports = 1");
+    expect(result.missing).toBeNull();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,6 +162,7 @@ export { Nodepod } from "./sdk/nodepod";
 export { NodepodTerminal } from "./sdk/nodepod-terminal";
 export { NodepodProcess } from "./sdk/nodepod-process";
 export { NodepodFS } from "./sdk/nodepod-fs";
+export { NodepodFSClient, NodepodFSClientError } from "./sdk/nodepod-fs-client";
 export type {
   NodepodOptions,
   TerminalOptions,
@@ -182,6 +183,7 @@ export { VFSBridge } from "./threading/vfs-bridge";
 export { WorkerVFS } from "./threading/worker-vfs";
 export { SyncChannelController, SyncChannelWorker } from "./threading/sync-channel";
 export { SharedVFSController, SharedVFSReader, isSharedArrayBufferAvailable } from "./threading/shared-vfs";
+export type { SharedVFSStat } from "./threading/shared-vfs";
 export { createProcessContext, getActiveContext, setActiveContext } from "./threading/process-context";
 export type { ProcessContext, ProcessWriter, ProcessReader, OpenFileEntry } from "./threading/process-context";
 export type {

--- a/src/sdk/nodepod-fs-client.ts
+++ b/src/sdk/nodepod-fs-client.ts
@@ -1,0 +1,104 @@
+// read-only fs client for sibling workers. on main call
+// nodepod.sharedFSBuffer, postMessage it to the worker, then on the worker
+// side do Nodepod.attachFS(buffer) and you get this. reads hit the shared
+// buffer directly so there's no IPC per call.
+//
+// writes aren't supported (the canonical MemoryVolume lives on the main
+// thread, a sibling writing directly would desync it). send write requests
+// back over a MessagePort if you need them.
+
+import { SharedVFSReader } from "../threading/shared-vfs";
+import type { SharedVFSStat } from "../threading/shared-vfs";
+
+export class NodepodFSClientError extends Error {
+  readonly code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+    this.name = "NodepodFSClientError";
+  }
+}
+
+function notSupported(op: string): never {
+  throw new NodepodFSClientError(
+    "ENOTSUP",
+    `NodepodFSClient is read-only, ${op}() not supported from a sibling worker. ` +
+      `route the call back to the thread that booted nodepod and use nodepod.fs.${op}() there.`,
+  );
+}
+
+export class NodepodFSClient {
+  constructor(private _reader: SharedVFSReader) {}
+
+  async readFile(path: string, encoding: "utf-8" | "utf8"): Promise<string>;
+  async readFile(path: string): Promise<Uint8Array>;
+  async readFile(path: string, encoding?: string): Promise<string | Uint8Array> {
+    const bytes = this._reader.readFileSync(path);
+    if (bytes === null) {
+      throw new NodepodFSClientError("ENOENT", `ENOENT: no such file, open '${path}'`);
+    }
+    if (encoding === "utf8" || encoding === "utf-8") {
+      // reader already returns a non-shared copy, so TextDecoder is happy
+      return new TextDecoder().decode(bytes);
+    }
+    return bytes;
+  }
+
+  async exists(path: string): Promise<boolean> {
+    return this._reader.existsSync(path);
+  }
+
+  async stat(path: string): Promise<SharedVFSStat> {
+    const s = this._reader.statSync(path);
+    if (s === null) {
+      throw new NodepodFSClientError("ENOENT", `ENOENT: no such file or directory, stat '${path}'`);
+    }
+    return s;
+  }
+
+  async readdir(path: string): Promise<string[]> {
+    // match node: scandir on missing path throws ENOENT (except root)
+    if (!this._reader.existsSync(path) && path !== "/") {
+      throw new NodepodFSClientError("ENOENT", `ENOENT: no such file or directory, scandir '${path}'`);
+    }
+    return this._reader.readdirSync(path);
+  }
+
+  /** SAB version counter, bumped on every write/delete. */
+  get version(): number {
+    return this._reader.version;
+  }
+
+  /**
+   * Block until the version changes or timeout. returns the new version, or
+   * -1 on timeout. don't call this on a browser main thread, Atomics.wait
+   * throws there.
+   */
+  waitForChange(currentVersion: number, timeoutMs: number = 5000): number {
+    return this._reader.waitForChange(currentVersion, timeoutMs);
+  }
+
+  async writeFile(_path: string, _data: string | Uint8Array): Promise<void> {
+    notSupported("writeFile");
+  }
+  async mkdir(_path: string, _opts?: { recursive?: boolean }): Promise<void> {
+    notSupported("mkdir");
+  }
+  async unlink(_path: string): Promise<void> {
+    notSupported("unlink");
+  }
+  async rmdir(_path: string, _opts?: { recursive?: boolean }): Promise<void> {
+    notSupported("rmdir");
+  }
+  async rename(_from: string, _to: string): Promise<void> {
+    notSupported("rename");
+  }
+  async appendFile(_path: string, _data: string | Uint8Array): Promise<void> {
+    notSupported("appendFile");
+  }
+
+  /** escape hatch if you need the sync reader directly */
+  get reader(): SharedVFSReader {
+    return this._reader;
+  }
+}

--- a/src/sdk/nodepod.ts
+++ b/src/sdk/nodepod.ts
@@ -27,7 +27,9 @@ import { VFSBridge } from "../threading/vfs-bridge";
 import {
   isSharedArrayBufferAvailable,
   SharedVFSController,
+  SharedVFSReader,
 } from "../threading/shared-vfs";
+import { NodepodFSClient } from "./nodepod-fs-client";
 import { SyncChannelController } from "../threading/sync-channel";
 import { MemoryHandler } from "../memory-handler";
 import { openSnapshotCache } from "../persistence/idb-cache";
@@ -651,6 +653,33 @@ export class Nodepod {
       };
     }
     return { vfs, engine, heap };
+  }
+
+  /**
+   * postMessage this to a sibling worker (one the host app spawned, not one
+   * nodepod spawned via spawn()), then call Nodepod.attachFS(buffer) on the
+   * other side. null if SAB is unavailable, but boot() would have thrown in
+   * that case so this is mostly defensive.
+   *
+   * caps: 16,384 entries, 64 MB, 248-byte paths. writes past the caps
+   * silently drop, not ideal for node_modules scale scans.
+   */
+  get sharedFSBuffer(): SharedArrayBuffer | null {
+    return this._sharedVFS?.buffer ?? null;
+  }
+
+  /**
+   * attach to an existing nodepod from a sibling worker using the buffer
+   * from nodepod.sharedFSBuffer. the returned client is read-only, writes
+   * throw ENOTSUP.
+   */
+  static attachFS(buffer: SharedArrayBuffer): NodepodFSClient {
+    if (!isSharedArrayBufferAvailable()) {
+      throw new Error(
+        "[Nodepod.attachFS] SharedArrayBuffer is required. Ensure COOP/COEP headers are set.",
+      );
+    }
+    return new NodepodFSClient(new SharedVFSReader(buffer));
   }
 
   /* ---- Escape hatches ---- */

--- a/src/threading/shared-vfs.ts
+++ b/src/threading/shared-vfs.ts
@@ -48,6 +48,14 @@ const DATA_OFFSET = HEADER_SIZE + TABLE_SIZE;
 
 const DEFAULT_BUFFER_SIZE = 64 * 1024 * 1024; // 64MB
 
+export interface SharedVFSStat {
+  isFile: boolean;
+  isDirectory: boolean;
+  size: number;
+  /** ms since epoch. resolution is seconds, the SAB only stores seconds. */
+  mtime: number;
+}
+
 /* ------------------------------------------------------------------ */
 /*  FNV-1a hash                                                        */
 /* ------------------------------------------------------------------ */
@@ -314,6 +322,51 @@ export class SharedVFSReader {
     return (flags & FLAG_ACTIVE) !== 0 && (flags & FLAG_DIRECTORY) !== 0;
   }
 
+  statSync(path: string): SharedVFSStat | null {
+    const idx = this._findEntry(path);
+    if (idx === -1) return null;
+    const entryOffset = HEADER_SIZE + idx * ENTRY_SIZE;
+    const flags = this._view.getUint32(entryOffset + ENTRY_FLAGS_OFFSET);
+    if (!(flags & FLAG_ACTIVE)) return null;
+    const isDirectory = (flags & FLAG_DIRECTORY) !== 0;
+    const contentLength = this._view.getUint32(entryOffset + ENTRY_CONTENT_LENGTH);
+    const modified = this._view.getUint32(entryOffset + ENTRY_MODIFIED_OFFSET);
+    return {
+      isFile: !isDirectory,
+      isDirectory,
+      size: isDirectory ? 0 : contentLength,
+      mtime: modified * 1000,
+    };
+  }
+
+  // immediate children only, basenames, O(n) over the entry table.
+  // returns [] for missing paths.
+  readdirSync(dir: string): string[] {
+    const prefix = dir === "/" ? "/" : dir.endsWith("/") ? dir : dir + "/";
+    const entryCount = Atomics.load(this._int32, 1);
+    const names: string[] = [];
+    const seen = new Set<string>();
+
+    for (let i = 0; i < entryCount; i++) {
+      const entryOffset = HEADER_SIZE + i * ENTRY_SIZE;
+      const flags = this._view.getUint32(entryOffset + ENTRY_FLAGS_OFFSET);
+      if (!(flags & FLAG_ACTIVE)) continue;
+
+      const path = this._readPath(entryOffset);
+      if (!path.startsWith(prefix) || path === prefix) continue;
+
+      // strip prefix then take up to the next slash, skip nested entries
+      const rest = path.slice(prefix.length);
+      const slashIdx = rest.indexOf("/");
+      const name = slashIdx === -1 ? rest : rest.slice(0, slashIdx);
+      if (!name || seen.has(name)) continue;
+      seen.add(name);
+      names.push(name);
+    }
+
+    return names;
+  }
+
   get version(): number {
     return Atomics.load(this._int32, 0);
   }
@@ -348,5 +401,18 @@ export class SharedVFSReader {
       }
     }
     return -1;
+  }
+
+  // decode a null-terminated path from an entry. needs a non-shared copy
+  // because TextDecoder throws on SAB views.
+  private _readPath(entryOffset: number): string {
+    let end = 0;
+    while (end < ENTRY_PATH_MAX && this._uint8[entryOffset + ENTRY_PATH_OFFSET + end] !== 0) {
+      end++;
+    }
+    if (end === 0) return "";
+    const copy = new Uint8Array(end);
+    copy.set(this._uint8.subarray(entryOffset + ENTRY_PATH_OFFSET, entryOffset + ENTRY_PATH_OFFSET + end));
+    return this._pathDecoder.decode(copy);
   }
 }

--- a/src/threading/vfs-bridge.ts
+++ b/src/threading/vfs-bridge.ts
@@ -206,26 +206,31 @@ export class VFSBridge {
     const handle = this._volume.watch("/", { recursive: true }, (event, filename) => {
       if (!filename || this._suppressWatch) return;
 
+      // watch callbacks get filenames relative to the watch root, so
+      // writing /hello.txt while watching / comes through as "hello.txt".
+      // SharedVFS and broadcast keys are absolute, promote it here.
+      const absPath = filename.startsWith("/") ? filename : "/" + filename;
+
       try {
-        if (this._volume.existsSync(filename)) {
-          const stat = this._volume.statSync(filename);
+        if (this._volume.existsSync(absPath)) {
+          const stat = this._volume.statSync(absPath);
           if (stat.isDirectory()) {
-            this.broadcastChange(filename, new ArrayBuffer(0), -1);
-            if (this._sharedVFS) this._sharedVFS.writeDirectory(filename);
+            this.broadcastChange(absPath, new ArrayBuffer(0), -1);
+            if (this._sharedVFS) this._sharedVFS.writeDirectory(absPath);
           } else {
-            const data = this._volume.readFileSync(filename);
+            const data = this._volume.readFileSync(absPath);
             // fresh ArrayBuffer copy — VFS nodes may store SAB-backed Uint8Arrays when written from WASM threads, and SAB isn't transferable via postMessage
             const buffer = new ArrayBuffer(data.byteLength);
             new Uint8Array(buffer).set(data);
-            this.broadcastChange(filename, buffer, -1);
-            if (this._sharedVFS) this._sharedVFS.writeFile(filename, data);
+            this.broadcastChange(absPath, buffer, -1);
+            if (this._sharedVFS) this._sharedVFS.writeFile(absPath, data);
           }
         } else {
-          this.broadcastChange(filename, null, -1);
-          if (this._sharedVFS) this._sharedVFS.deleteFile(filename);
+          this.broadcastChange(absPath, null, -1);
+          if (this._sharedVFS) this._sharedVFS.deleteFile(absPath);
         }
       } catch (e) {
-        console.warn(`[VFSBridge] Watch error for "${filename}":`, e);
+        console.warn(`[VFSBridge] Watch error for "${absPath}":`, e);
       }
     });
 


### PR DESCRIPTION
exposes nodepod.sharedFSBuffer and Nodepod.attachFS(buffer) so workers the host app spawns (not ones from nodepod.spawn) can read the VFS directly without postMessage per call. returned client is read-only, writes throw ENOTSUP and should be routed back to the booting thread over a MessagePort.

covers the reader half of the ask in ScelarOrg/Nodepod#31.

also fixes a latent bug in VFSBridge.watch: MemoryVolume passes filenames relative to the watch root, so writing /hello.txt was getting stored in SharedVFS under "hello.txt". nothing read that before since spawned workers use handleWorkerWrite + createSnapshot which both pass absolute paths already, but attachFS made it observable. bridge now promotes to absolute before forwarding.

- src/sdk/nodepod-fs-client.ts (new): read-only fs shape
- src/sdk/nodepod.ts: sharedFSBuffer + attachFS
- src/threading/shared-vfs.ts: statSync + readdirSync on reader
- src/threading/vfs-bridge.ts: relative to absolute in watch callback
- src/__tests__/shared-vfs.test.ts: 40 tests incl cross-thread
- examples/shared-fs-attach: runnable demo