### PR TITLE
feat(sdk): add enableSharedArrayBuffer opt-out flag

### DIFF
--- a/examples/sab-opt-out/index.html
+++ b/examples/sab-opt-out/index.html
@@ -1,0 +1,164 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>nodepod - SharedArrayBuffer opt-out</title>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      body { font-family: monospace; background: #1a1a2e; color: #e0e0e0; padding: 24px; line-height: 1.6; }
+      h1 { font-size: 18px; margin-bottom: 4px; color: #fff; }
+      h2 { font-size: 14px; margin: 20px 0 8px; color: #8ac4e6; }
+      p { font-size: 13px; color: #888; margin-bottom: 12px; }
+      code { background: #0d0d1a; padding: 2px 6px; border-radius: 3px; color: #a8e6a3; }
+      .demo { background: #0d0d1a; border: 1px solid #333; border-radius: 6px; padding: 16px; margin-bottom: 16px; }
+      button { background: #2a2a4a; color: #e0e0e0; border: 1px solid #444; border-radius: 4px; padding: 8px 14px; font-family: monospace; cursor: pointer; margin-right: 8px; margin-top: 8px; }
+      button:hover { background: #3a3a5a; }
+      button:disabled { opacity: 0.5; cursor: not-allowed; }
+      pre { background: #000; padding: 10px; border-radius: 3px; font-size: 12px; overflow-x: auto; margin-top: 8px; white-space: pre-wrap; color: #ccc; }
+      .ok { color: #a8e6a3; }
+      .err { color: #e68a8a; }
+      .warn { color: #e6c88a; }
+      .info { color: #8ac4e6; }
+      .dim { color: #555; }
+    </style>
+  </head>
+  <body>
+    <h1>nodepod · SharedArrayBuffer opt-out</h1>
+    <p>
+      By default nodepod uses SharedArrayBuffer for sync fs reads,
+      <code>execSync</code>/<code>spawnSync</code>, and threaded wasi modules
+      (rolldown, lightningcss, tailwind-oxide). Pass
+      <code>enableSharedArrayBuffer: false</code> to force it off.
+      Dependent features either degrade to async message passing, or
+      lazy-throw when actually invoked.
+    </p>
+
+    <div class="demo">
+      <h2>1 · Default boot (SAB on)</h2>
+      <p>
+        Happy path, matches what every other example does. Both a regular
+        script and <code>execSync</code> work.
+      </p>
+      <button id="default-boot">Boot with SAB on</button>
+      <pre id="default-out" class="dim">(click to run)</pre>
+    </div>
+
+    <div class="demo">
+      <h2>2 · Opt-out: <code>{ enableSharedArrayBuffer: false }</code></h2>
+      <p>
+        Boot still succeeds, you get a warn in devtools.
+        <code>isSharedArrayBufferEnabled</code> reads false. Regular scripts
+        and async fs still work. Common builtins like <code>echo</code>,
+        <code>ls</code>, <code>cat</code>, <code>pwd</code>, version checks
+        etc. have fast-paths that run in pure JS and still work. Anything
+        that needs a real subprocess (like
+        <code>execSync("node -e ...")</code>) throws with a message that
+        tells you how to turn SAB back on.
+      </p>
+      <button id="off-boot">Boot with SAB off</button>
+      <pre id="off-out" class="dim">(click to run)</pre>
+    </div>
+
+    <script type="module">
+      import { Nodepod } from "/dist/index.mjs";
+
+      function writeLine(el, text, cls = "") {
+        const line = document.createElement("div");
+        if (cls) line.className = cls;
+        line.textContent = text;
+        el.appendChild(line);
+      }
+      function resetOut(id) {
+        const el = document.getElementById(id);
+        el.textContent = "";
+        el.className = "";
+        return el;
+      }
+
+      const REGULAR_SCRIPT = `
+const os = require('os');
+const fs = require('fs');
+console.log('platform:', os.platform());
+fs.writeFileSync('/tmp/hello.txt', 'hi from partial mode');
+console.log('read back:', fs.readFileSync('/tmp/hello.txt', 'utf8'));
+`.trim();
+
+      // lots of commands have fast-paths inside child_process.handleSyncCommand
+      // (echo, pwd, cat, ls, uname, test, git, version checks) so they work
+      // without the sync channel. to actually hit the Atomics.wait route we
+      // need to spawn a real subprocess. node -e does that.
+      const EXECSYNC_SCRIPT = `
+const { execSync } = require('child_process');
+try {
+  const out = execSync('echo hi');
+  console.log('fast-path echo ok:', out.toString().trim());
+} catch (e) {
+  console.error('fast-path echo threw:', e.message);
+}
+try {
+  const out = execSync('node -e "console.log(2+2)"');
+  console.log('blocking node -e ok:', out.toString().trim());
+} catch (e) {
+  console.error('blocking node -e threw:', e.message);
+}
+`.trim();
+
+      async function bootAndRun(out, opts) {
+        writeLine(out, "> Nodepod.boot(" + JSON.stringify(opts) + ")", "dim");
+        const pod = await Nodepod.boot({
+          ...opts,
+          serviceWorker: false,
+          files: {
+            "/regular.js": REGULAR_SCRIPT,
+            "/exec.js": EXECSYNC_SCRIPT,
+          },
+        });
+        writeLine(
+          out,
+          "isSharedArrayBufferEnabled = " + pod.isSharedArrayBufferEnabled,
+          pod.isSharedArrayBufferEnabled ? "ok" : "warn",
+        );
+
+        writeLine(out, "", "dim");
+        writeLine(out, "> node regular.js", "dim");
+        const p1 = await pod.spawn("node", ["regular.js"]);
+        p1.on("output", (t) => writeLine(out, t.trimEnd(), "ok"));
+        p1.on("error", (t) => writeLine(out, t.trimEnd(), "err"));
+        await p1.completion;
+
+        writeLine(out, "", "dim");
+        writeLine(out, "> node exec.js", "dim");
+        const p2 = await pod.spawn("node", ["exec.js"]);
+        p2.on("output", (t) => writeLine(out, t.trimEnd(), "ok"));
+        p2.on("error", (t) => writeLine(out, t.trimEnd(), "err"));
+        await p2.completion;
+
+        return pod;
+      }
+
+      document.getElementById("default-boot").addEventListener("click", async () => {
+        const out = resetOut("default-out");
+        try {
+          await bootAndRun(out, {});
+          writeLine(out, "", "dim");
+          writeLine(out, "done", "info");
+        } catch (e) {
+          writeLine(out, "boot failed: " + e.message, "err");
+        }
+      });
+
+      document.getElementById("off-boot").addEventListener("click", async () => {
+        const out = resetOut("off-out");
+        writeLine(out, "(check devtools console for the boot warn)", "dim");
+        try {
+          await bootAndRun(out, { enableSharedArrayBuffer: false });
+          writeLine(out, "", "dim");
+          writeLine(out, "done. echo works (fast-path), node -e threw (needed real blocking)", "info");
+        } catch (e) {
+          writeLine(out, "boot failed: " + e.message, "err");
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/examples/serve.js
+++ b/examples/serve.js
@@ -52,4 +52,5 @@ createServer((req, res) => {
   console.log(`  SW setup DX:          http://localhost:${port}/examples/sw-setup/`);
   console.log(`  Terminal resize:      http://localhost:${port}/examples/terminal-resize/`);
   console.log(`  Shared FS attach:     http://localhost:${port}/examples/shared-fs-attach/`);
+  console.log(`  SAB opt-out:          http://localhost:${port}/examples/sab-opt-out/`);
 });

--- a/src/__tests__/nodepod-sab.test.ts
+++ b/src/__tests__/nodepod-sab.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// the virtual module is provided by a vite plugin only in the lib build,
+// tests run under vitest without that plugin so we stub it here
+vi.mock("virtual:process-worker-bundle", () => ({
+  PROCESS_WORKER_BUNDLE: "",
+}));
+
+import { Nodepod } from "../sdk/nodepod";
+
+// Worker is not global in node, stub so boot can get past the worker check.
+// SW is opted out via serviceWorker: false so no navigator bits are touched.
+
+describe("Nodepod SAB opt-out", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let workerWasSet = false;
+  let sabBackup: typeof SharedArrayBuffer | undefined;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    if (typeof (globalThis as any).Worker === "undefined") {
+      (globalThis as any).Worker = function MockWorker() {} as any;
+      workerWasSet = true;
+    }
+    sabBackup = (globalThis as any).SharedArrayBuffer;
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    if (workerWasSet) {
+      delete (globalThis as any).Worker;
+      workerWasSet = false;
+    }
+    if (sabBackup) {
+      (globalThis as any).SharedArrayBuffer = sabBackup;
+    }
+  });
+
+  it("default boot keeps SAB on and does not warn", async () => {
+    const pod = await Nodepod.boot({ serviceWorker: false });
+    expect(pod.isSharedArrayBufferEnabled).toBe(true);
+    const pm = (pod as any)._processManager;
+    expect(pm._sharedBuffer).not.toBeNull();
+    expect(pm._syncBuffer).not.toBeNull();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("enableSharedArrayBuffer: false forces SAB off even when available", async () => {
+    const pod = await Nodepod.boot({
+      serviceWorker: false,
+      enableSharedArrayBuffer: false,
+    });
+    expect(pod.isSharedArrayBufferEnabled).toBe(false);
+    const pm = (pod as any)._processManager;
+    expect(pm._sharedBuffer).toBeNull();
+    expect(pm._syncBuffer).toBeNull();
+
+    const msg = warnSpy.mock.calls.flat().join(" ");
+    expect(msg).toContain("SharedArrayBuffer");
+    expect(msg).toContain("disabled");
+  });
+
+  it("missing SAB runtime does not throw, boot degrades and warns", async () => {
+    delete (globalThis as any).SharedArrayBuffer;
+
+    const pod = await Nodepod.boot({ serviceWorker: false });
+    expect(pod.isSharedArrayBufferEnabled).toBe(false);
+    const pm = (pod as any)._processManager;
+    expect(pm._sharedBuffer).toBeNull();
+    expect(pm._syncBuffer).toBeNull();
+
+    const msg = warnSpy.mock.calls.flat().join(" ");
+    expect(msg).toContain("SharedArrayBuffer");
+    expect(msg).toContain("unavailable");
+  });
+});

--- a/src/helpers/napi-wasm-worker.ts
+++ b/src/helpers/napi-wasm-worker.ts
@@ -169,6 +169,7 @@ export function createNapiWorkerFactory(
   processEnv: Record<string, string>,
   fsBridge: any, // for handling __fs__ proxy messages
   fallbackWorkerFn: ((...args: any[]) => any) | null,
+  sabEnabled: boolean,
 ) {
   // bundled scripts don't change at runtime, so cache per entry path
   const bundleCache = new Map<string, string>();
@@ -181,6 +182,19 @@ export function createNapiWorkerFactory(
     const scriptStr = typeof script === "string" ? script : script.href;
 
     if (isNapiWasiWorkerScript(scriptStr, vol)) {
+      // threaded wasi needs SAB for Atomics.wait, would deadlock without it
+      if (!sabEnabled) {
+        queueMicrotask(() => {
+          this.emit?.(
+            "error",
+            new Error(
+              `[Nodepod] ${scriptStr} needs SharedArrayBuffer (threaded wasi module). ` +
+                "enable COOP/COEP headers, or drop `enableSharedArrayBuffer: false` from NodepodOptions.",
+            ),
+          );
+        });
+        return;
+      }
       return createRealWebWorker.call(
         this,
         scriptStr,

--- a/src/polyfills/child_process.ts
+++ b/src/polyfills/child_process.ts
@@ -40,6 +40,7 @@ const _nativeSetTimeout: typeof globalThis.setTimeout =
   globalThis.setTimeout.bind(globalThis);
 
 let _syncChannel: SyncChannelWorker | null = null;
+let _sabEnabled = true;
 
 let _stdoutSink: ((text: string) => void) | null = null;
 let _stderrSink: ((text: string) => void) | null = null;
@@ -162,6 +163,10 @@ export function clearStreamingCallbacks(): void {
 // set the SyncChannelWorker for true blocking execSync/spawnSync in worker mode
 export function setSyncChannel(channel: SyncChannelWorker): void {
   _syncChannel = channel;
+}
+
+export function setSabEnabled(enabled: boolean): void {
+  _sabEnabled = enabled;
 }
 
 // onStdout/onStderr fire in real-time as output arrives; promise resolves on child exit
@@ -353,6 +358,7 @@ function evalNodeCode(code: string, ctx: ShellContext): ShellResult {
   const sandbox = new ScriptEngine(_vol!, {
     cwd: ctx.cwd,
     env: ctx.env,
+    enableSharedArrayBuffer: _sabEnabled,
     onConsole: (m: string, args: unknown[]) => {
       const line = utilFormat(args[0], ...args.slice(1)) + "\n";
       m === "error" ? (err += line) : (out += line);
@@ -381,6 +387,7 @@ function printNodeCode(code: string, ctx: ShellContext): ShellResult {
   const sandbox = new ScriptEngine(_vol!, {
     cwd: ctx.cwd,
     env: ctx.env,
+    enableSharedArrayBuffer: _sabEnabled,
     onConsole: (m: string, args: unknown[]) => {
       const line = utilFormat(args[0], ...args.slice(1)) + "\n";
       m === "error" ? (err += line) : (out += line);
@@ -1129,6 +1136,7 @@ export async function executeNodeBinary(
   const sandbox = new ScriptEngine(_vol, {
     cwd: ctx.cwd,
     env: ctx.env,
+    enableSharedArrayBuffer: _sabEnabled,
     onConsole: (m: string, cArgs: unknown[]) => {
       // filter out process.exit sentinel errors logged by library code
       if (cArgs.length === 1) {
@@ -1795,8 +1803,8 @@ export function execSync(cmd: string, opts?: RunOptions): string | Buffer {
   // true blocking path via Atomics.wait()
   if (!_syncChannel) {
     throw new Error(
-      "[Nodepod] execSync requires SyncChannel (worker mode with SharedArrayBuffer). " +
-      "Ensure Nodepod is running in worker mode with COOP/COEP headers.",
+      "[Nodepod] execSync needs SharedArrayBuffer + SyncChannel. " +
+      "enable COOP/COEP headers, or drop `enableSharedArrayBuffer: false` from NodepodOptions.",
     );
   }
 
@@ -2225,8 +2233,8 @@ export function spawnSync(
   // true blocking path via Atomics.wait()
   if (!_syncChannel) {
     throw new Error(
-      "[Nodepod] spawnSync requires SyncChannel (worker mode with SharedArrayBuffer). " +
-      "Ensure Nodepod is running in worker mode with COOP/COEP headers.",
+      "[Nodepod] spawnSync needs SharedArrayBuffer + SyncChannel. " +
+      "enable COOP/COEP headers, or drop `enableSharedArrayBuffer: false` from NodepodOptions.",
     );
   }
 
@@ -2485,6 +2493,7 @@ export default {
   clearStreamingCallbacks,
   sendStdin,
   setSyncChannel,
+  setSabEnabled,
   setSpawnChildCallback,
   setForkChildCallback,
   setIPCSend,

--- a/src/script-engine.ts
+++ b/src/script-engine.ts
@@ -879,6 +879,7 @@ export interface EngineOptions {
     threadId: number;
   };
   handler?: import("./memory-handler").MemoryHandler;
+  enableSharedArrayBuffer?: boolean;
 }
 
 export interface ResolverFn {
@@ -2118,6 +2119,7 @@ export class ScriptEngine {
         this.proc.env as Record<string, string>,
         this.fsBridge,
         (threadPoolPolyfill as any)._workerThreadForkFn ?? null,
+        this.opts.enableSharedArrayBuffer ?? true,
       );
       threadPoolPolyfill.setWorkerConstructorOverride((self, script, opts) => {
         workerFactory.call(self, script, opts);

--- a/src/sdk/nodepod.ts
+++ b/src/sdk/nodepod.ts
@@ -49,6 +49,7 @@ export class Nodepod {
   private _syncChannel: SyncChannelController | null = null;
   private _unwatchVFS: (() => void) | null = null;
   private _handler: MemoryHandler;
+  private _sabEnabled: boolean;
 
   /* ---- Construction (use Nodepod.boot()) ---- */
 
@@ -59,6 +60,7 @@ export class Nodepod {
     cwd: string,
     handler: MemoryHandler,
     env: Record<string, string>,
+    sabEnabled: boolean,
   ) {
     this._volume = volume;
     this._packages = packages;
@@ -66,6 +68,7 @@ export class Nodepod {
     this._cwd = cwd;
     this._env = env;
     this._handler = handler;
+    this._sabEnabled = sabEnabled;
     this.fs = new NodepodFS(volume);
     this._processManager = new ProcessManager(volume);
     this._vfsBridge = new VFSBridge(volume);
@@ -85,7 +88,7 @@ export class Nodepod {
     // VFS watcher broadcasts main-thread file changes to workers (needed for HMR)
     this._unwatchVFS = this._vfsBridge.watch();
 
-    if (isSharedArrayBufferAvailable()) {
+    if (sabEnabled) {
       try {
         this._sharedVFS = new SharedVFSController();
         this._processManager.setSharedBuffer(this._sharedVFS.buffer);
@@ -99,6 +102,14 @@ export class Nodepod {
         this._processManager.setSyncBuffer(this._syncChannel.buffer);
       } catch (e) {
         // SyncChannel init failed
+      }
+
+      // SAB was detected but controllers failed, probably COOP/COEP
+      if (!this._sharedVFS || !this._syncChannel) {
+        this._sabEnabled = false;
+        console.warn(
+          "[Nodepod] SharedArrayBuffer init failed mid-boot, features disabled.",
+        );
       }
     }
 
@@ -154,9 +165,18 @@ export class Nodepod {
         "[Nodepod] Web Workers are required. Nodepod cannot run without Web Worker support.",
       );
     }
-    if (typeof SharedArrayBuffer === "undefined") {
-      throw new Error(
-        "[Nodepod] SharedArrayBuffer is required. Ensure Cross-Origin-Isolation headers are set (Cross-Origin-Opener-Policy: same-origin, Cross-Origin-Embedder-Policy: credentialless).",
+
+    const sabAvailable = isSharedArrayBufferAvailable();
+    const sabEnabled = opts.enableSharedArrayBuffer !== false && sabAvailable;
+    if (!sabEnabled) {
+      const reason = !sabAvailable
+        ? "unavailable (likely missing COOP/COEP headers)"
+        : "disabled via enableSharedArrayBuffer: false";
+      console.warn(
+        `[Nodepod] SharedArrayBuffer ${reason}. ` +
+          "execSync/spawnSync will throw on call, threaded wasi modules " +
+          "(rolldown, lightningcss, tailwind-oxide) will refuse to load, " +
+          "cross-thread vfs reads use async message passing.",
       );
     }
 
@@ -189,7 +209,15 @@ export class Nodepod {
       setAllowedDomains(opts.allowedFetchDomains ?? []);
     }
 
-    const nodepod = new Nodepod(volume, packages, proxy, cwd, handler, env);
+    const nodepod = new Nodepod(
+      volume,
+      packages,
+      proxy,
+      cwd,
+      handler,
+      env,
+      sabEnabled,
+    );
 
     if (opts.files) {
       for (const [path, content] of Object.entries(opts.files)) {
@@ -705,5 +733,9 @@ export class Nodepod {
   }
   get cwd(): string {
     return this._cwd;
+  }
+  /** true if SAB features are active on this instance */
+  get isSharedArrayBufferEnabled(): boolean {
+    return this._sabEnabled;
   }
 }

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -27,6 +27,15 @@ export interface NodepodOptions {
   memory?: MemoryHandlerOptions;
   /** Cache installed node_modules in IndexedDB for faster re-boots. Default: true. */
   enableSnapshotCache?: boolean;
+  /**
+   * set to false to force SAB off even if the runtime has it.
+   * useful for envs without COOP/COEP or for testing partial mode.
+   * when off: execSync/spawnSync throw on call, threaded wasi modules
+   * (rolldown, lightningcss, tailwind-oxide) refuse to load, and cross
+   * thread vfs reads fall back to async message passing.
+   * defaults to true.
+   */
+  enableSharedArrayBuffer?: boolean;
   /** domains allowed through the cors proxy. merged with built-in defaults
    *  (npm, github, esm.sh etc). pass null to allow everything */
   allowedFetchDomains?: string[] | null;

--- a/src/threading/process-worker-entry.ts
+++ b/src/threading/process-worker-entry.ts
@@ -24,6 +24,7 @@ let _suppressVFSWatch = false;
 let _shellInitialized = false;
 let _shellMod: typeof import("../polyfills/child_process") | null = null;
 let _syncChannelWorker: SyncChannelWorker | null = null;
+let _sabEnabled = true;
 let _ipcMessageHandler: ((data: unknown) => void) | null = null;
 let _cols = 80;
 let _rows = 24;
@@ -184,6 +185,8 @@ function handleInit(msg: MainToWorker_Init): void {
   if (msg.syncBuffer) {
     _syncChannelWorker = new SyncChannelWorker(msg.syncBuffer);
   }
+  // if main had SAB off, neither buffer was sent
+  _sabEnabled = !!msg.syncBuffer;
 
   _initialized = true;
   post({ type: "ready", pid: _pid });
@@ -200,6 +203,7 @@ async function ensureShell(): Promise<typeof import("../polyfills/child_process"
     if (_syncChannelWorker) {
       _shellMod.setSyncChannel(_syncChannelWorker);
     }
+    _shellMod.setSabEnabled(_sabEnabled);
     _shellMod.setSpawnChildCallback(spawnChild);
     _shellMod.setForkChildCallback(forkChild);
     const wtMod = await import("../polyfills/worker_threads");


### PR DESCRIPTION
previously Nodepod.boot() hard-threw when SAB was missing which broke any host without COOP/COEP headers. now theres an explicit flag you can set to false and boot still succeeds with a warn. missing SAB at runtime also degrades gracefully instead of crashing.

features that need SAB auto-disable when its off:
- execSync/spawnSync throw at call time (fast-path builtins like echo/ls/cat/pwd/git still work)
- threaded wasi modules (rolldown, lightningcss, tailwind-oxide) refuse to load with a clear error
- cross-thread vfs reads fall back to async message passing
- uhm, probably some more that i cant think of rn.

defaults to true so existing code keeps working exactly as-is. adds isSharedArrayBufferEnabled getter, a new example at examples/sab-opt-out, and 3 tests. related to #36