### PR TITLE
Fix/npm install

### DIFF
--- a/src/packages/version-resolver.ts
+++ b/src/packages/version-resolver.ts
@@ -85,8 +85,25 @@ export function satisfiesRange(version: string, range: string): boolean {
   const sv = parseSemver(version);
   if (!sv) return false;
 
-  // pre-release versions only match ranges that explicitly include one
-  if (sv.prerelease && !range.includes("-")) return false;
+  // pre-release versions only match ranges that explicitly include a prerelease
+  // for the SAME major.minor.patch (npm semantics). e.g. 5.0.0-next.0 matches
+  // ^5.0.0-beta.0 but NOT >=4.0.0-beta.0 (different major.minor.patch)
+  if (sv.prerelease) {
+    // Extract the comparator version(s) from the range and check if any
+    // share the same major.minor.patch as the candidate
+    const rangeVersions = range.match(/\d+\.\d+\.\d+(?:-[^\s)]*)?/g) || [];
+    const hasMatchingPrerelease = rangeVersions.some((rv) => {
+      if (!rv.includes("-")) return false;
+      const rvParsed = parseSemver(rv);
+      return (
+        rvParsed &&
+        rvParsed.major === sv.major &&
+        rvParsed.minor === sv.minor &&
+        rvParsed.patch === sv.patch
+      );
+    });
+    if (!hasMatchingPrerelease) return false;
+  }
 
   range = range.trim();
 
@@ -502,8 +519,12 @@ async function installPackageAt(
   }
 
   if (versionInfo.optionalDependencies) {
+    const optEntries = Object.entries(versionInfo.optionalDependencies);
+
     if (state.config.optionalDependencies) {
-      Object.assign(edges, versionInfo.optionalDependencies);
+      for (const [optName, optRange] of optEntries) {
+        edges[optName] = optRange as string;
+      }
     } else {
       // Always include wasm32-wasi optional deps — they're WASM alternatives
       // to native bindings and are the only variant that can run in-browser
@@ -518,9 +539,7 @@ async function installPackageAt(
 
       // generic napi-rs detection: if ALL optional deps are platform-specific
       // native bindings (contain OS/arch tags) but no WASM variant exists, try
-      // {pkg}-wasm32-wasi and {pkg}-wasm as alternatives. covers packages like
-      // lightningcss that ship a separate -wasm package. errors are swallowed
-      // since these may not exist on the registry
+      // {pkg}-wasm32-wasi and {pkg}-wasm as alternatives
       if (!hasWasmVariant && optNames.length >= 2) {
         const platformRe = /-(darwin|linux|win32|freebsd|android|sunos)-(x64|x86|arm64|arm|ia32|s390x|ppc64|mips|riscv)/;
         const allPlatform = optNames.every(n => platformRe.test(n));

--- a/src/packages/version-resolver.ts
+++ b/src/packages/version-resolver.ts
@@ -539,7 +539,9 @@ async function installPackageAt(
 
       // generic napi-rs detection: if ALL optional deps are platform-specific
       // native bindings (contain OS/arch tags) but no WASM variant exists, try
-      // {pkg}-wasm32-wasi and {pkg}-wasm as alternatives
+      // {pkg}-wasm32-wasi and {pkg}-wasm as alternatives. covers packages like
+      // lightningcss that ship a separate -wasm package. errors are swallowed
+      // since these may not exist on the registry
       if (!hasWasmVariant && optNames.length >= 2) {
         const platformRe = /-(darwin|linux|win32|freebsd|android|sunos)-(x64|x86|arm64|arm|ia32|s390x|ppc64|mips|riscv)/;
         const allPlatform = optNames.every(n => platformRe.test(n));


### PR DESCRIPTION
There's an issue during installation of some npm packages. Nodepod was crashing because package resolution does not found it right. 

I've found that for a case of `@stencil/core` - it was trying to find a version `^5.0.0` but  for now (`22.04.2026`) the only available versions for `@stencil/core@5` is `alpha` or `next`. On my OS npm resolved that by getting `@4` instead of `@5`. 

This fix aims to simulate the same as OS npm.

Best,