### PR TITLE
fix: multi-tab SW routing, chrome delete+reload hang, hard refresh hang

### DIFF
--- a/examples/multi-boot-race/index.html
+++ b/examples/multi-boot-race/index.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>nodepod - multi-boot race (reproduces #39)</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: monospace; background: #1a1a2e; color: #e0e0e0; padding: 24px; }
+    h1 { font-size: 18px; margin-bottom: 8px; color: #fff; }
+    p { font-size: 13px; color: #888; margin-bottom: 16px; max-width: 820px; line-height: 1.5; }
+    .controls { margin-bottom: 16px; display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+    button {
+      background: #2a2a4a; color: #e0e0e0; border: 1px solid #444;
+      padding: 6px 14px; border-radius: 4px; font-family: monospace; cursor: pointer;
+    }
+    button:hover { background: #3a3a5a; }
+    button:disabled { opacity: 0.5; cursor: not-allowed; }
+    label { font-size: 13px; color: #aaa; }
+    input[type=number] {
+      background: #0d0d1a; color: #e0e0e0; border: 1px solid #444;
+      padding: 4px 8px; border-radius: 4px; width: 60px; font-family: monospace;
+    }
+    #output {
+      background: #0d0d1a; border: 1px solid #333; border-radius: 6px;
+      padding: 16px; min-height: 400px; white-space: pre-wrap;
+      font-size: 13px; line-height: 1.55; overflow-y: auto;
+    }
+    .stdout { color: #a8e6a3; }
+    .stderr { color: #e68a8a; }
+    .info { color: #8ac4e6; }
+    .dim { color: #555; }
+    .pass { color: #a8e6a3; }
+    .fail { color: #e68a8a; font-weight: bold; }
+    .warn { color: #e6c38a; }
+    .hang { color: #e68a8a; font-weight: bold; background: #3a1010; padding: 0 4px; }
+    code { background: #2a2a4a; padding: 1px 5px; border-radius: 3px; }
+  </style>
+</head>
+<body>
+  <h1>nodepod - multi-boot race (reproduces <a href="https://github.com/ScelarOrg/Nodepod/issues/39" style="color:#8ac4e6">#39</a>)</h1>
+  <p>
+    Reproduces: "when booting multiple Nodepod instances at once, the boot promises sometimes never resolve".
+    Click <b>Run</b> to fire N <code>Nodepod.boot()</code> calls in parallel via <code>Promise.allSettled()</code>.
+    Each boot is wrapped in a <code>BOOT_TIMEOUT_MS</code> watchdog, any boot that doesn't settle within that
+    window is flagged as <span class="hang">HUNG</span>. Adjust the instance count and re-run, higher counts
+    (4+) make the hang much more likely to appear.
+  </p>
+
+  <div class="controls">
+    <label>Instances: <input id="count" type="number" value="4" min="2" max="16"></label>
+    <label>Timeout (ms): <input id="timeout" type="number" value="30000" min="1000" step="1000"></label>
+    <label><input id="sw" type="checkbox" checked> Service worker</label>
+    <button id="run">Run</button>
+    <button id="clear">Clear log</button>
+  </div>
+
+  <div id="output"></div>
+
+  <script type="module">
+    import { Nodepod } from "/dist/index.mjs";
+
+    const out = document.getElementById('output');
+    const countInput = document.getElementById('count');
+    const timeoutInput = document.getElementById('timeout');
+    const swInput = document.getElementById('sw');
+    const runBtn = document.getElementById('run');
+    const clearBtn = document.getElementById('clear');
+
+    function log(text, cls = 'stdout') {
+      const span = document.createElement('span');
+      span.className = cls;
+      span.textContent = text + '\n';
+      out.appendChild(span);
+      out.scrollTop = out.scrollHeight;
+    }
+
+    clearBtn.addEventListener('click', () => { out.innerHTML = ''; });
+
+    // boot one instance with a timeout watchdog.
+    // returns { idx, state: 'resolved'|'rejected'|'hung', ms, error?, nodepod? }
+    function bootWithTimeout(idx, timeoutMs, serviceWorker) {
+      const t0 = performance.now();
+      let hungTimer;
+      const hung = new Promise((resolve) => {
+        hungTimer = setTimeout(() => {
+          resolve({ idx, state: 'hung', ms: performance.now() - t0 });
+        }, timeoutMs);
+      });
+
+      const boot = Nodepod.boot({
+        // separate workdir per instance so they're clearly independent
+        workdir: `/i${idx}`,
+        serviceWorker,
+        files: {
+          [`/i${idx}/hello.js`]: `console.log('hello from instance ${idx}, pid=' + process.pid);`,
+        },
+      }).then(
+        (nodepod) => {
+          clearTimeout(hungTimer);
+          return { idx, state: 'resolved', ms: performance.now() - t0, nodepod };
+        },
+        (error) => {
+          clearTimeout(hungTimer);
+          return { idx, state: 'rejected', ms: performance.now() - t0, error };
+        },
+      );
+
+      return Promise.race([boot, hung]);
+    }
+
+    async function run() {
+      runBtn.disabled = true;
+      const count = Math.max(2, Math.min(16, parseInt(countInput.value, 10) || 4));
+      const timeoutMs = Math.max(1000, parseInt(timeoutInput.value, 10) || 30000);
+      const serviceWorker = swInput.checked;
+
+      log(`\n=== Firing ${count} Nodepod.boot() calls in parallel (timeout ${timeoutMs}ms, serviceWorker=${serviceWorker}) ===`, 'info');
+      log(`User agent: ${navigator.userAgent}`, 'dim');
+      log(`crossOriginIsolated: ${self.crossOriginIsolated}`, 'dim');
+      log(`SharedArrayBuffer: ${typeof SharedArrayBuffer !== 'undefined'}`, 'dim');
+      log(`navigator.serviceWorker: ${'serviceWorker' in navigator}`, 'dim');
+      log('', 'dim');
+
+      const t0 = performance.now();
+      const starts = Array.from({ length: count }, (_, i) => {
+        log(`[${i}] boot() called at t=${(performance.now() - t0).toFixed(0)}ms`, 'dim');
+        return bootWithTimeout(i, timeoutMs, serviceWorker);
+      });
+
+      // stream each result as it settles instead of waiting on all
+      const pending = new Set(starts.map((_, i) => i));
+      const results = new Array(count);
+
+      await Promise.all(starts.map(async (p, i) => {
+        const r = await p;
+        results[i] = r;
+        pending.delete(i);
+        if (r.state === 'resolved') {
+          log(`[${i}] RESOLVED in ${r.ms.toFixed(0)}ms`, 'pass');
+        } else if (r.state === 'rejected') {
+          log(`[${i}] REJECTED in ${r.ms.toFixed(0)}ms: ${r.error?.message ?? r.error}`, 'fail');
+        } else {
+          log(`[${i}] HUNG, no settle after ${r.ms.toFixed(0)}ms  (still waiting)`, 'hang');
+        }
+      }));
+
+      const total = performance.now() - t0;
+      const resolved = results.filter(r => r.state === 'resolved').length;
+      const rejected = results.filter(r => r.state === 'rejected').length;
+      const hung = results.filter(r => r.state === 'hung').length;
+
+      log('', 'dim');
+      log(`=== Summary (wall time ${total.toFixed(0)}ms) ===`, 'info');
+      log(`  resolved: ${resolved} / ${count}`, resolved === count ? 'pass' : 'stdout');
+      log(`  rejected: ${rejected} / ${count}`, rejected > 0 ? 'fail' : 'dim');
+      log(`  hung:     ${hung} / ${count}`, hung > 0 ? 'hang' : 'dim');
+
+      if (hung > 0) {
+        log('', 'dim');
+        log(`REPRODUCED ISSUE #39: ${hung} boot promise(s) never resolved within ${timeoutMs}ms.`, 'fail');
+        log('These workers/service-workers may still be alive in devtools > Application > Service Workers', 'warn');
+      } else if (resolved === count) {
+        log('', 'dim');
+        log(`All ${count} instances booted successfully this round. Try again, the race is non-deterministic.`, 'warn');
+      }
+
+      runBtn.disabled = false;
+    }
+
+    runBtn.addEventListener('click', run);
+
+    // auto-run once on load so the bug is visible immediately
+    log('Page ready. Click Run, or wait - auto-running with default settings in 500ms...', 'info');
+    setTimeout(run, 500);
+  </script>
+</body>
+</html>

--- a/examples/serve.js
+++ b/examples/serve.js
@@ -53,4 +53,5 @@ createServer((req, res) => {
   console.log(`  Terminal resize:      http://localhost:${port}/examples/terminal-resize/`);
   console.log(`  Shared FS attach:     http://localhost:${port}/examples/shared-fs-attach/`);
   console.log(`  SAB opt-out:          http://localhost:${port}/examples/sab-opt-out/`);
+  console.log(`  Multi-boot race (#39):http://localhost:${port}/examples/multi-boot-race/`);
 });

--- a/src/__tests__/integrations/multi-instance-proxy.test.ts
+++ b/src/__tests__/integrations/multi-instance-proxy.test.ts
@@ -1,0 +1,268 @@
+// tests for RequestProxy multi-tenant behavior: N Nodepods sharing one proxy
+// (and one browser SW) without clobbering each other.
+//
+// these run in Node so there's no real SW. focus is on the main-thread
+// state machine: attach/detach, per-instance isolation, routing by
+// instanceId, URL shape, legacy single-tenant back-compat
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { EventEmitter } from "events";
+import {
+  RequestProxy,
+  DEFAULT_INSTANCE,
+  type IVirtualServer,
+} from "../../request-proxy";
+
+// fake process manager, just enough for attach() and the _handleWs* paths to
+// not blow up. lets us assert without a real worker pool
+class FakeProcessManager extends EventEmitter {
+  public wsUpgrades: Array<[number, string, string, any]> = [];
+  public wsData: Array<[number, string, number[]]> = [];
+  public wsCloses: Array<[number, string, number]> = [];
+  dispatchWsUpgrade(port: number, uid: string, path: string, headers: any): number {
+    this.wsUpgrades.push([port, uid, path, headers]);
+    return 42; // pretend a worker pid accepted it
+  }
+  dispatchWsData(pid: number, uid: string, frame: number[]): void {
+    this.wsData.push([pid, uid, frame]);
+  }
+  dispatchWsClose(pid: number, uid: string, code: number): void {
+    this.wsCloses.push([pid, uid, code]);
+  }
+}
+
+// minimal virtual server that echoes the request. used to prove the proxy
+// picked the right instance's server by checking the label in the response
+function makeServer(label: string): IVirtualServer {
+  return {
+    listening: true,
+    address: () => ({ port: 0, address: "0.0.0.0", family: "IPv4" }),
+    async dispatchRequest(method, url) {
+      return {
+        statusCode: 200,
+        statusMessage: "OK",
+        headers: { "content-type": "text/plain", "x-server": label },
+        body: Buffer.from(`${label}:${method} ${url}`),
+      };
+    },
+  };
+}
+
+describe("RequestProxy multi-instance", () => {
+  let proxy: RequestProxy;
+
+  beforeEach(() => {
+    proxy = new RequestProxy({ baseUrl: "http://test.local" });
+  });
+
+  describe("attach / detach", () => {
+    it("attaches two instances independently", () => {
+      const pm1 = new FakeProcessManager();
+      const pm2 = new FakeProcessManager();
+      proxy.attach("pod-aaa", pm1);
+      proxy.attach("pod-bbb", pm2);
+      // Both should accept registrations without clobbering each other
+      proxy.register("pod-aaa", makeServer("A"), 3000);
+      proxy.register("pod-bbb", makeServer("B"), 3000);
+      expect(proxy.activePorts("pod-aaa")).toEqual([3000]);
+      expect(proxy.activePorts("pod-bbb")).toEqual([3000]);
+    });
+
+    it("detach() releases an instance's ports without touching siblings", () => {
+      const pm1 = new FakeProcessManager();
+      const pm2 = new FakeProcessManager();
+      proxy.attach("pod-aaa", pm1);
+      proxy.attach("pod-bbb", pm2);
+      proxy.register("pod-aaa", makeServer("A"), 3000);
+      proxy.register("pod-bbb", makeServer("B"), 3000);
+
+      proxy.detach("pod-aaa");
+      expect(proxy.activePorts("pod-aaa")).toEqual([]);
+      expect(proxy.activePorts("pod-bbb")).toEqual([3000]);
+    });
+
+    it("detach() is safe to call on an unknown instance", () => {
+      expect(() => proxy.detach("nonexistent")).not.toThrow();
+    });
+
+    it("rejects invalid instanceIds", () => {
+      const pm = new FakeProcessManager();
+      // all-digits would collide with port in URL parsing
+      expect(() => proxy.attach("12345", pm)).toThrow(/invalid instanceId/);
+      // empty
+      expect(() => proxy.attach("", pm)).toThrow(/invalid instanceId/);
+      // has a slash
+      expect(() => proxy.attach("bad/id", pm)).toThrow(/invalid instanceId/);
+    });
+
+    it("DEFAULT_INSTANCE is accepted even though it's a reserved short id", () => {
+      const pm = new FakeProcessManager();
+      expect(() => proxy.attach(DEFAULT_INSTANCE, pm)).not.toThrow();
+    });
+
+    it("re-attach rewires the process manager and removes the old ws-frame listener", () => {
+      const pm1 = new FakeProcessManager();
+      const pm2 = new FakeProcessManager();
+      proxy.attach("pod-x", pm1);
+      expect(pm1.listenerCount("ws-frame")).toBe(1);
+      proxy.attach("pod-x", pm2);
+      expect(pm1.listenerCount("ws-frame")).toBe(0);
+      expect(pm2.listenerCount("ws-frame")).toBe(1);
+    });
+  });
+
+  describe("server registry isolation", () => {
+    it("two instances can bind the same port without collision", async () => {
+      proxy.attach("pod-aaa", new FakeProcessManager());
+      proxy.attach("pod-bbb", new FakeProcessManager());
+      proxy.register("pod-aaa", makeServer("A"), 3000);
+      proxy.register("pod-bbb", makeServer("B"), 3000);
+
+      const respA = await proxy.handleRequest("pod-aaa", 3000, "GET", "/", {});
+      const respB = await proxy.handleRequest("pod-bbb", 3000, "GET", "/", {});
+      expect(respA.headers["x-server"]).toBe("A");
+      expect(respB.headers["x-server"]).toBe("B");
+    });
+
+    it("handleRequest to an unknown instance returns 503", async () => {
+      const resp = await proxy.handleRequest("pod-nope", 3000, "GET", "/", {});
+      expect(resp.statusCode).toBe(503);
+    });
+
+    it("unregister on one instance doesn't remove the other's entry", () => {
+      proxy.attach("pod-aaa", new FakeProcessManager());
+      proxy.attach("pod-bbb", new FakeProcessManager());
+      proxy.register("pod-aaa", makeServer("A"), 3000);
+      proxy.register("pod-bbb", makeServer("B"), 3000);
+
+      proxy.unregister("pod-aaa", 3000);
+      expect(proxy.activePorts("pod-aaa")).toEqual([]);
+      expect(proxy.activePorts("pod-bbb")).toEqual([3000]);
+    });
+  });
+
+  describe("URL shape", () => {
+    it("serverUrl includes the instanceId segment", () => {
+      expect(proxy.serverUrl("pod-aaa", 3000)).toBe(
+        "http://test.local/__virtual__/pod-aaa/3000",
+      );
+    });
+
+    it("legacy serverUrl(port) routes to DEFAULT_INSTANCE", () => {
+      expect(proxy.serverUrl(3000)).toBe(
+        `http://test.local/__virtual__/${DEFAULT_INSTANCE}/3000`,
+      );
+    });
+  });
+
+  describe("createFetchHandler URL routing", () => {
+    it("parses new-shape /__virtual__/{instanceId}/{port}/{path}", async () => {
+      proxy.attach("pod-aaa", new FakeProcessManager());
+      proxy.register("pod-aaa", makeServer("A"), 3000);
+      const handler = proxy.createFetchHandler();
+      const resp = await handler(
+        new Request("http://test.local/__virtual__/pod-aaa/3000/foo"),
+      );
+      expect(resp.status).toBe(200);
+      expect(resp.headers.get("x-server")).toBe("A");
+      expect(await resp.text()).toBe("A:GET /foo");
+    });
+
+    it("parses legacy /__virtual__/{port}/{path} as DEFAULT_INSTANCE", async () => {
+      proxy.attach(DEFAULT_INSTANCE, new FakeProcessManager());
+      proxy.register(DEFAULT_INSTANCE, makeServer("D"), 3000);
+      const handler = proxy.createFetchHandler();
+      const resp = await handler(
+        new Request("http://test.local/__virtual__/3000/foo"),
+      );
+      expect(resp.status).toBe(200);
+      expect(resp.headers.get("x-server")).toBe("D");
+    });
+  });
+
+  describe("legacy single-tenant API", () => {
+    it("setProcessManager + register(server, port) routes to DEFAULT_INSTANCE", async () => {
+      const pm = new FakeProcessManager();
+      proxy.setProcessManager(pm);
+      proxy.register(makeServer("L"), 4000);
+      expect(proxy.activePorts(DEFAULT_INSTANCE)).toEqual([4000]);
+      const resp = await proxy.handleRequest(4000, "GET", "/", {});
+      expect(resp.statusCode).toBe(200);
+      expect(resp.headers["x-server"]).toBe("L");
+    });
+
+    it("unregister(port) with no instanceId routes to DEFAULT_INSTANCE", () => {
+      proxy.setProcessManager(new FakeProcessManager());
+      proxy.register(makeServer("L"), 4000);
+      proxy.unregister(4000);
+      expect(proxy.activePorts(DEFAULT_INSTANCE)).toEqual([]);
+    });
+
+    it("activePorts() with no arg returns the union across all instances", () => {
+      proxy.attach("pod-aaa", new FakeProcessManager());
+      proxy.attach("pod-bbb", new FakeProcessManager());
+      proxy.register("pod-aaa", makeServer("A"), 3000);
+      proxy.register("pod-bbb", makeServer("B"), 4000);
+      expect(proxy.activePorts().sort()).toEqual([3000, 4000]);
+    });
+  });
+
+  describe("server-ready events", () => {
+    it("emits the instance-scoped URL on server-ready", () => {
+      proxy.attach("pod-aaa", new FakeProcessManager());
+      const seen: Array<[number, string]> = [];
+      proxy.on("server-ready", (port: number, url: string) => {
+        seen.push([port, url]);
+      });
+      proxy.register("pod-aaa", makeServer("A"), 3000);
+      expect(seen).toEqual([
+        [3000, "http://test.local/__virtual__/pod-aaa/3000"],
+      ]);
+    });
+
+    it("fires onServerReady callback with instance-scoped URL", () => {
+      const seen: string[] = [];
+      const p = new RequestProxy({
+        baseUrl: "http://test.local",
+        onServerReady: (_port, url) => seen.push(url),
+      });
+      p.attach("pod-aaa", new FakeProcessManager());
+      p.register("pod-aaa", makeServer("A"), 3000);
+      expect(seen).toEqual(["http://test.local/__virtual__/pod-aaa/3000"]);
+    });
+  });
+
+  describe("initServiceWorker memoization", () => {
+    it("concurrent callers share one in-flight promise", async () => {
+      // fire 7 concurrent initServiceWorker() calls. the old bug was 6 of 7
+      // getting stuck in Chromium's SW-registration queue because every boot
+      // raced through getRegistrations/unregister/register with no guard.
+      // fix memoizes the in-flight promise. in Node there's no
+      // navigator.serviceWorker so the inner promise rejects, but before the
+      // rejection propagates all 7 callers must see the same promise object
+      const results = [
+        proxy.initServiceWorker({ skipPreflight: true }),
+        proxy.initServiceWorker({ skipPreflight: true }),
+        proxy.initServiceWorker({ skipPreflight: true }),
+        proxy.initServiceWorker({ skipPreflight: true }),
+        proxy.initServiceWorker({ skipPreflight: true }),
+        proxy.initServiceWorker({ skipPreflight: true }),
+        proxy.initServiceWorker({ skipPreflight: true }),
+      ];
+      for (let i = 1; i < results.length; i++) {
+        expect(results[i]).toBe(results[0]);
+      }
+      // swallow the expected rejection (no navigator.serviceWorker in Node)
+      await results[0].catch(() => {});
+    });
+
+    it("allows retry after a failed init (promise is cleared on rejection)", async () => {
+      const p1 = proxy.initServiceWorker({ skipPreflight: true });
+      await p1.catch(() => {});
+      // should get a fresh promise with a different identity
+      const p2 = proxy.initServiceWorker({ skipPreflight: true });
+      expect(p2).not.toBe(p1);
+      await p2.catch(() => {});
+    });
+  });
+});

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -178,6 +178,9 @@ export const TIMEOUTS = {
   SYNC_OP: 120_000,
   WAIT_LOOP_TICK: 200,
   SW_HEARTBEAT: 20_000,
+  /** cap on navigator.serviceWorker.ready so init doesn't hang forever if the
+   *  SW gets stuck installing/waiting */
+  SW_ACTIVATION: 10_000,
   WORKER_REAP_INTERVAL: 10_000,
   WORKER_IDLE_TIMEOUT: 30_000,
   WORKER_INIT_TIMEOUT: 30_000,

--- a/src/request-proxy.ts
+++ b/src/request-proxy.ts
@@ -1,5 +1,11 @@
 // bridges Service Worker HTTP requests to virtual servers.
 // intercepts browser fetches via SW and routes them to the http polyfill's server registry.
+//
+// multi-tenant: one RequestProxy singleton (one SW per scope), state is
+// multiplexed across N Nodepods by instanceId. each Nodepod attach()/detach()s
+// and routes its servers/preview scripts/WS bridge under its own id. SW fetches
+// carry /__virtual__/{instanceId}/{port}/... back to the right instance.
+// Legacy /__virtual__/{port}/... falls back to DEFAULT_INSTANCE.
 
 import type { CompletedResponse } from "./polyfills/http";
 import {
@@ -24,6 +30,17 @@ export { NodepodSWSetupError };
 export type { NodepodSWFrameworkHint } from "./integrations/shared/errors";
 
 const _enc = new TextEncoder();
+
+/** used by legacy zero-arg callers (createWorkspace, setServerListenCallback).
+ *  multi-tenant callers pass their own instanceId */
+export const DEFAULT_INSTANCE = "default";
+
+/** id must be non-empty, url-safe, and have at least one non-digit so the url
+ *  parser can tell it apart from a port number */
+function isValidInstanceId(id: string): boolean {
+  if (!id || !/^[A-Za-z0-9_-]+$/.test(id)) return false;
+  return /\D/.test(id);
+}
 
 export interface IVirtualServer {
   listening: boolean;
@@ -56,21 +73,44 @@ export interface ServiceWorkerConfig {
   skipPreflight?: boolean;
 }
 
+interface InstanceState {
+  processManager: any | null;
+  previewScript: string | null;
+  wsBridgeToken: string | null;
+  registry: Map<number, RegisteredServer>;
+  workerWsConns: Map<string, { pid: number }>;
+  wsConns: Map<
+    string,
+    { socket: import("./polyfills/net").TcpSocket; cleanup: () => void }
+  >;
+  /** kept so detach() can remove it */
+  wsFrameListener: ((msg: any) => void) | null;
+}
+
 export { CompletedResponse };
 
 export class RequestProxy extends EventEmitter {
   static DEBUG = false;
-  private registry = new Map<number, RegisteredServer>();
+  // ── Shared (process-wide) state ──
   private baseUrl: string;
   private opts: ProxyOptions;
   private channel: MessageChannel | null = null;
   private swReady = false;
   private heartbeat: ReturnType<typeof setInterval> | null = null;
-  private _processManager: any | null = null;
-  private _workerWsConns = new Map<string, { pid: number }>();
-  private _previewScript: string | null = null;
   private _swAuthToken: string | null = null;
-  private _wsBridgeToken: string | null = null;
+  /** memoizes concurrent initServiceWorker() callers so N parallel boots
+   *  don't kick off N registrations that hang Chromium */
+  private _swInitPromise: Promise<void> | null = null;
+  /** global, not per-instance. last writer wins across tabs */
+  private _watermarkEnabled = true;
+  /** guards pagehide/beforeunload listener registration so reinit doesn't stack them */
+  private _farewellInstalled = false;
+
+  // ── Per-instance state, keyed by instanceId ──
+  private _instances = new Map<string, InstanceState>();
+
+  // ── WS bridge (one BroadcastChannel for the page, messages tagged per-instance) ──
+  private _wsBridge: BroadcastChannel | null = null;
 
   constructor(opts: ProxyOptions = {}) {
     super();
@@ -80,42 +120,191 @@ export class RequestProxy extends EventEmitter {
         ? opts.baseUrl || `${location.protocol}//${location.host}`
         : opts.baseUrl || "http://localhost";
 
+    // legacy http polyfill callbacks fire only when main thread calls
+    // http.createServer().listen() directly (createWorkspace path). routed
+    // to DEFAULT_INSTANCE. Nodepod SDK uses register(instanceId, ...) instead
     setServerListenCallback((port, srv) => this.register(srv, port));
     setServerCloseCallback((port) => this.unregister(port));
   }
 
-  setProcessManager(pm: any): void {
-    this._processManager = pm;
-    pm.on("ws-frame", (msg: any) => {
-      this._handleWorkerWsFrame(msg);
-    });
+  private _getOrCreateInstance(instanceId: string): InstanceState {
+    let inst = this._instances.get(instanceId);
+    if (!inst) {
+      inst = {
+        processManager: null,
+        previewScript: null,
+        wsBridgeToken: null,
+        registry: new Map(),
+        workerWsConns: new Map(),
+        wsConns: new Map(),
+        wsFrameListener: null,
+      };
+      this._instances.set(instanceId, inst);
+    }
+    return inst;
   }
 
+  // ── Instance lifecycle ──
+
+  /** attach a Nodepod to this proxy. idempotent: re-attaching with the same
+   *  id rewires the process manager but keeps registry/preview script etc */
+  attach(instanceId: string, processManager: any): void {
+    if (instanceId !== DEFAULT_INSTANCE && !isValidInstanceId(instanceId)) {
+      throw new Error(
+        `[RequestProxy] invalid instanceId ${JSON.stringify(instanceId)}: ` +
+          `must be URL-safe and contain at least one non-digit char`,
+      );
+    }
+    const inst = this._getOrCreateInstance(instanceId);
+
+    // drop the old ws-frame listener on re-attach
+    if (inst.processManager && inst.wsFrameListener) {
+      try {
+        inst.processManager.removeListener?.(
+          "ws-frame",
+          inst.wsFrameListener,
+        );
+      } catch {
+        /* */
+      }
+    }
+
+    inst.processManager = processManager;
+    const listener = (msg: any) => this._handleWorkerWsFrame(instanceId, msg);
+    inst.wsFrameListener = listener;
+    processManager.on("ws-frame", listener);
+
+    // tell the SW which tab owns this instanceId so multi-tab fetches route
+    // correctly. without this Tab A's requests land on Tab B's RequestProxy
+    this.notifySW("claim-instance", { instanceId });
+  }
+
+  /** detach an instance, unregister all its servers and tear down its ws
+   *  connections. safe on an unknown id */
+  detach(instanceId: string): void {
+    const inst = this._instances.get(instanceId);
+    if (!inst) return;
+
+    for (const port of [...inst.registry.keys()]) {
+      this.notifySW("server-unregistered", { instanceId, port });
+    }
+    // release the routing claim so future fetches for this instance 503
+    // instead of hitting stale state
+    this.notifySW("release-instance", { instanceId });
+
+    if (inst.processManager && inst.wsFrameListener) {
+      try {
+        inst.processManager.removeListener?.(
+          "ws-frame",
+          inst.wsFrameListener,
+        );
+      } catch {
+        /* */
+      }
+    }
+
+    for (const { cleanup } of inst.wsConns.values()) {
+      try {
+        cleanup();
+      } catch {
+        /* */
+      }
+    }
+
+    this._instances.delete(instanceId);
+  }
+
+  /** @deprecated use attach(instanceId, pm). legacy callers route to DEFAULT_INSTANCE */
+  setProcessManager(pm: any): void {
+    this.attach(DEFAULT_INSTANCE, pm);
+  }
+
+  // ── Server registration ──
+
+  register(
+    instanceId: string,
+    server: Server | IVirtualServer,
+    port: number,
+    hostname?: string,
+  ): void;
   register(
     server: Server | IVirtualServer,
     port: number,
-    hostname = "0.0.0.0",
-  ): void {
-    this.registry.set(port, { server, port, hostname });
-    const url = this.serverUrl(port);
+    hostname?: string,
+  ): void;
+  register(...args: any[]): void {
+    let instanceId: string;
+    let server: Server | IVirtualServer;
+    let port: number;
+    let hostname: string;
+
+    if (typeof args[0] === "string") {
+      instanceId = args[0];
+      server = args[1];
+      port = args[2];
+      hostname = args[3] ?? "0.0.0.0";
+    } else {
+      instanceId = DEFAULT_INSTANCE;
+      server = args[0];
+      port = args[1];
+      hostname = args[2] ?? "0.0.0.0";
+    }
+
+    const inst = this._getOrCreateInstance(instanceId);
+    inst.registry.set(port, { server, port, hostname });
+    const url = this.serverUrl(instanceId, port);
+    // flat (port, url) shape kept for back-compat with existing listeners
     this.emit("server-ready", port, url);
     this.opts.onServerReady?.(port, url);
-    this.notifySW("server-registered", { port, hostname });
+    this.notifySW("server-registered", { instanceId, port, hostname });
   }
 
-  unregister(port: number): void {
-    this.registry.delete(port);
-    this.notifySW("server-unregistered", { port });
+  unregister(instanceId: string, port: number): void;
+  unregister(port: number): void;
+  unregister(...args: any[]): void {
+    let instanceId: string;
+    let port: number;
+    if (typeof args[0] === "string") {
+      instanceId = args[0];
+      port = args[1];
+    } else {
+      instanceId = DEFAULT_INSTANCE;
+      port = args[0];
+    }
+    const inst = this._instances.get(instanceId);
+    if (!inst) return;
+    inst.registry.delete(port);
+    this.notifySW("server-unregistered", { instanceId, port });
   }
 
   // Sends a script to the Service Worker that gets injected into every HTML
   // response served to preview iframes. Runs before any page content.
-  setPreviewScript(script: string | null): void {
-    this._previewScript = script;
-    this._sendPreviewScriptToSW();
+  setPreviewScript(instanceId: string, script: string | null): void;
+  setPreviewScript(script: string | null): void;
+  setPreviewScript(...args: any[]): void {
+    let instanceId: string;
+    let script: string | null;
+    if (args.length >= 2 || (args.length === 1 && typeof args[0] === "string" && isValidInstanceId(args[0]))) {
+      // 2 args means (instanceId, script). 1 string arg is the legacy shape
+      // where the string is the script itself
+      if (args.length >= 2) {
+        instanceId = args[0];
+        script = args[1];
+      } else {
+        instanceId = DEFAULT_INSTANCE;
+        script = args[0];
+      }
+    } else {
+      instanceId = DEFAULT_INSTANCE;
+      script = args[0] ?? null;
+    }
+    const inst = this._getOrCreateInstance(instanceId);
+    inst.previewScript = script;
+    this._sendPreviewScriptToSW(instanceId);
   }
 
   setWatermark(enabled: boolean): void {
+    this._watermarkEnabled = enabled;
     if (
       typeof navigator !== "undefined" &&
       navigator.serviceWorker?.controller
@@ -128,54 +317,101 @@ export class RequestProxy extends EventEmitter {
     }
   }
 
-  private _sendPreviewScriptToSW(): void {
+  private _sendPreviewScriptToSW(instanceId: string): void {
     if (
-      typeof navigator !== "undefined" &&
-      navigator.serviceWorker?.controller
+      typeof navigator === "undefined" ||
+      !navigator.serviceWorker?.controller
     ) {
-      navigator.serviceWorker.controller.postMessage({
-        type: "set-preview-script",
-        script: this._previewScript,
-        token: this._swAuthToken,
-      });
+      return;
     }
+    const inst = this._instances.get(instanceId);
+    if (!inst) return;
+    navigator.serviceWorker.controller.postMessage({
+      type: "set-preview-script",
+      instanceId,
+      script: inst.previewScript,
+      token: this._swAuthToken,
+    });
   }
 
-  private _sendWsTokenToSW(): void {
+  private _sendWsTokenToSW(instanceId: string): void {
     if (
-      typeof navigator !== "undefined" &&
-      navigator.serviceWorker?.controller
+      typeof navigator === "undefined" ||
+      !navigator.serviceWorker?.controller
     ) {
-      navigator.serviceWorker.controller.postMessage({
-        type: "set-ws-token",
-        wsToken: this._wsBridgeToken,
-        token: this._swAuthToken,
-      });
+      return;
     }
+    const inst = this._instances.get(instanceId);
+    if (!inst) return;
+    navigator.serviceWorker.controller.postMessage({
+      type: "set-ws-token",
+      instanceId,
+      wsToken: inst.wsBridgeToken,
+      token: this._swAuthToken,
+    });
   }
 
-  serverUrl(port: number): string {
-    return `${this.baseUrl}/__virtual__/${port}`;
+  serverUrl(instanceId: string, port: number): string;
+  serverUrl(port: number): string;
+  serverUrl(a: string | number, b?: number): string {
+    const instanceId = typeof a === "string" ? a : DEFAULT_INSTANCE;
+    const port = typeof a === "string" ? (b as number) : a;
+    return `${this.baseUrl}/__virtual__/${instanceId}/${port}`;
   }
 
-  activePorts(): number[] {
-    return [...this.registry.keys()];
+  /** ports registered with the given instance. no arg returns the union
+   *  across all instances (flat-list back-compat) */
+  activePorts(instanceId?: string): number[] {
+    if (instanceId !== undefined) {
+      const inst = this._instances.get(instanceId);
+      return inst ? [...inst.registry.keys()] : [];
+    }
+    const all = new Set<number>();
+    for (const inst of this._instances.values()) {
+      for (const p of inst.registry.keys()) all.add(p);
+    }
+    return [...all];
   }
 
+  async handleRequest(
+    instanceId: string,
+    port: number,
+    method: string,
+    url: string,
+    headers: Record<string, string>,
+    body?: ArrayBuffer,
+  ): Promise<CompletedResponse>;
   async handleRequest(
     port: number,
     method: string,
     url: string,
     headers: Record<string, string>,
     body?: ArrayBuffer,
-  ): Promise<CompletedResponse> {
-    const entry = this.registry.get(port);
+  ): Promise<CompletedResponse>;
+  async handleRequest(...args: any[]): Promise<CompletedResponse> {
+    let instanceId: string;
+    let port: number;
+    let method: string;
+    let url: string;
+    let headers: Record<string, string>;
+    let body: ArrayBuffer | undefined;
+    if (typeof args[0] === "string") {
+      [instanceId, port, method, url, headers, body] = args;
+    } else {
+      instanceId = DEFAULT_INSTANCE;
+      [port, method, url, headers, body] = args;
+    }
+
+    const inst = this._instances.get(instanceId);
+    const entry = inst?.registry.get(port);
     if (!entry) {
       return {
         statusCode: 503,
         statusMessage: "Service Unavailable",
         headers: { "Content-Type": "text/plain" },
-        body: Buffer.from(`No server on port ${port}`),
+        body: Buffer.from(
+          `No server on ${instanceId}/${port}`,
+        ),
       };
     }
     try {
@@ -233,7 +469,28 @@ export class RequestProxy extends EventEmitter {
     }
   }
 
-  async initServiceWorker(config?: ServiceWorkerConfig): Promise<void> {
+  /** concurrent callers share one in-flight promise, stops the Chromium
+   *  SW-registration storm when N Nodepods boot in parallel.
+   *
+   *  NOT async on purpose. an async wrapper would create a fresh outer
+   *  promise per call, so N callers each get their own identity and a
+   *  .catch() on the inner shared promise wouldn't reach them, causing
+   *  unhandled rejection warnings. returning the memoized promise directly
+   *  means all callers share one object */
+  initServiceWorker(config?: ServiceWorkerConfig): Promise<void> {
+    if (this.swReady) return Promise.resolve();
+    if (this._swInitPromise) return this._swInitPromise;
+    this._swInitPromise = this._doInitServiceWorker(config).catch((err) => {
+      // allow retry on failure
+      this._swInitPromise = null;
+      throw err;
+    });
+    return this._swInitPromise;
+  }
+
+  private async _doInitServiceWorker(
+    config?: ServiceWorkerConfig,
+  ): Promise<void> {
     if (!("serviceWorker" in navigator))
       throw new Error("Service Workers not supported");
 
@@ -243,70 +500,99 @@ export class RequestProxy extends EventEmitter {
       await this._preflightServiceWorker(swPath);
     }
 
-    // unregister old SWs and re-register with cache-busting to ensure latest __sw__.js
-    const existingRegs = await navigator.serviceWorker.getRegistrations();
-    for (const r of existingRegs) {
-      await r.unregister();
-    }
-    await new Promise(r => setTimeout(r, 100));
+    // fire and forget: register() can stall for seconds on hard refresh
+    // (Ctrl+Shift+R) while the browser reconciles the bypass. we don't need
+    // its promise to resolve, navigator.serviceWorker.ready below is the
+    // real signal
+    navigator.serviceWorker
+      .register(swPath, { scope: "/", updateViaCache: "none" })
+      .catch((err) => {
+        console.warn("[Nodepod] SW register() rejected:", err);
+      });
 
-    const controllerReady = new Promise<void>((res) => {
-      navigator.serviceWorker.addEventListener(
-        "controllerchange",
-        () => res(),
-        { once: true },
+    // .ready handles first install, repeat reload, hard refresh, and
+    // update-pending uniformly. timeout is a safety net
+    const reg = await Promise.race([
+      navigator.serviceWorker.ready,
+      new Promise<ServiceWorkerRegistration>((_, reject) =>
+        setTimeout(
+          () => reject(new Error("SW ready timeout")),
+          TIMEOUTS.SW_ACTIVATION,
+        ),
+      ),
+    ]);
+    const sw = reg.active;
+    if (!sw) {
+      throw new Error(
+        "Service Worker registration has no active worker after ready",
       );
-    });
-
-    const swUrl = `${swPath}?v=${Date.now()}`;
-    const reg = await navigator.serviceWorker.register(swUrl, { scope: "/", updateViaCache: "none" });
-
-    const sw = reg.installing || reg.waiting || reg.active;
-    if (!sw) throw new Error("Service Worker registration failed");
-
-    await new Promise<void>((resolve) => {
-      if (sw.state === "activated") return resolve();
-      const check = () => {
-        if (sw.state === "activated") {
-          sw.removeEventListener("statechange", check);
-          resolve();
-        }
-      };
-      sw.addEventListener("statechange", check);
-    });
+    }
 
     this._swAuthToken = crypto.randomUUID();
 
     this.channel = new MessageChannel();
     this.channel.port1.onmessage = this.onSWMessage.bind(this);
-    sw.postMessage({ type: "init", port: this.channel.port2, token: this._swAuthToken }, [
-      this.channel.port2,
-    ]);
+    sw.postMessage(
+      { type: "init", port: this.channel.port2, token: this._swAuthToken },
+      [this.channel.port2],
+    );
 
-    await controllerReady;
+    // claim every instance attached before the SW was ready. bypassing
+    // notifySW because swReady flips further down, but MessagePort delivery
+    // doesn't care: the browser queues messages on port2 until the SW sets
+    // its onmessage in the init handler
+    for (const id of this._instances.keys()) {
+      this.channel.port1.postMessage({
+        type: "claim-instance",
+        data: { instanceId: id },
+      });
+    }
 
+    // on SW update (controllerchange) the new SW has empty state. resend
+    // init + claims so it learns our routing table again
     const reinit = () => {
-      if (navigator.serviceWorker.controller) {
-        this.channel = new MessageChannel();
-        this.channel.port1.onmessage = this.onSWMessage.bind(this);
-        navigator.serviceWorker.controller.postMessage(
-          { type: "init", port: this.channel.port2, token: this._swAuthToken },
-          [this.channel.port2],
-        );
-        // Resend preview script to the new SW controller
-        if (this._previewScript !== null) {
-          this._sendPreviewScriptToSW();
-        }
-        // re-send ws bridge token too
-        if (this._wsBridgeToken) {
-          this._sendWsTokenToSW();
-        }
+      if (!navigator.serviceWorker.controller) return;
+      this.channel = new MessageChannel();
+      this.channel.port1.onmessage = this.onSWMessage.bind(this);
+      navigator.serviceWorker.controller.postMessage(
+        { type: "init", port: this.channel.port2, token: this._swAuthToken },
+        [this.channel.port2],
+      );
+      for (const id of this._instances.keys()) {
+        this.notifySW("claim-instance", { instanceId: id });
       }
+      for (const id of this._instances.keys()) {
+        const inst = this._instances.get(id)!;
+        if (inst.previewScript !== null) this._sendPreviewScriptToSW(id);
+        if (inst.wsBridgeToken) this._sendWsTokenToSW(id);
+      }
+      navigator.serviceWorker.controller.postMessage({
+        type: "set-watermark",
+        enabled: this._watermarkEnabled,
+        token: this._swAuthToken,
+      });
     };
     navigator.serviceWorker.addEventListener("controllerchange", reinit);
     navigator.serviceWorker.addEventListener("message", (ev) => {
       if (ev.data?.type === "sw-needs-init") reinit();
     });
+
+    // tell the SW to drop this tab's port + instance claims when the page
+    // goes away. without this a closed tab leaves stale routing entries and
+    // the next request for its instance times out after 30s. pagehide fires
+    // reliably (including bfcache), beforeunload is a backup
+    if (!this._farewellInstalled && typeof window !== "undefined") {
+      const farewell = () => {
+        try {
+          this.channel?.port1.postMessage({ type: "release-all" });
+        } catch {
+          // channel already torn down
+        }
+      };
+      window.addEventListener("pagehide", farewell);
+      window.addEventListener("beforeunload", farewell);
+      this._farewellInstalled = true;
+    }
 
     this.heartbeat = setInterval(() => {
       this.channel?.port1.postMessage({ type: "keepalive" });
@@ -316,14 +602,33 @@ export class RequestProxy extends EventEmitter {
     this.emit("sw-ready");
 
     this._startWsBridge();
+
+    // mint a ws token for every instance that attached before the SW was
+    // ready. common case: Nodepod constructor runs before initServiceWorker
+    // finishes because N parallel boots serialize here
+    for (const id of this._instances.keys()) {
+      this._ensureWsTokenForInstance(id);
+      this._sendWsTokenToSW(id);
+    }
   }
 
-  // strip /__preview__/{port} prefix from SW URLs if present
-  private _normalizeSwUrl(url: string, headers: Record<string, string>): string | null {
-    // Strip /__preview__/{port} prefix (fixes RSC HMR .rsc requests etc.)
-    const ppMatch = url.match(/^\/__preview__\/\d+(.*)?$/);
-    if (ppMatch) {
-      let stripped = ppMatch[1] || "/";
+  // strip /__preview__/{instanceId}/{port} or legacy /__preview__/{port} prefix
+  private _normalizeSwUrl(url: string, _headers: Record<string, string>): string | null {
+    // new: /__preview__/{instanceId}/{port}/rest
+    const newMatch = url.match(/^\/__preview__\/[^/]+\/\d+(.*)?$/);
+    if (newMatch) {
+      let stripped = newMatch[1] || "/";
+      if (stripped[0] !== "/") stripped = "/" + stripped;
+      const qIdx = url.indexOf("?");
+      if (qIdx >= 0 && !stripped.includes("?")) {
+        stripped += url.slice(qIdx);
+      }
+      return stripped;
+    }
+    // legacy: /__preview__/{port}/rest
+    const oldMatch = url.match(/^\/__preview__\/\d+(.*)?$/);
+    if (oldMatch) {
+      let stripped = oldMatch[1] || "/";
       if (stripped[0] !== "/") stripped = "/" + stripped;
       const qIdx = url.indexOf("?");
       if (qIdx >= 0 && !stripped.includes("?")) {
@@ -340,7 +645,16 @@ export class RequestProxy extends EventEmitter {
       console.log("[RequestProxy] SW:", type, id, data?.url);
 
     if (type === "request") {
-      const { port, method, headers, body, streaming, originalUrl } = data;
+      const {
+        instanceId: rawInstanceId,
+        port,
+        method,
+        headers,
+        body,
+        streaming,
+        originalUrl,
+      } = data;
+      const instanceId: string = rawInstanceId || DEFAULT_INSTANCE;
       let url: string = data.url;
 
       const normalized = this._normalizeSwUrl(url, headers);
@@ -350,9 +664,18 @@ export class RequestProxy extends EventEmitter {
 
       try {
         if (streaming) {
-          await this.handleStreaming(id, port, method, url, headers, body);
+          await this.handleStreaming(
+            instanceId,
+            id,
+            port,
+            method,
+            url,
+            headers,
+            body,
+          );
         } else {
           const resp = await this.handleRequest(
+            instanceId,
             port,
             method,
             url,
@@ -421,6 +744,7 @@ export class RequestProxy extends EventEmitter {
   }
 
   private async handleStreaming(
+    instanceId: string,
     id: number,
     port: number,
     method: string,
@@ -428,7 +752,8 @@ export class RequestProxy extends EventEmitter {
     headers: Record<string, string>,
     body?: ArrayBuffer,
   ): Promise<void> {
-    const entry = this.registry.get(port);
+    const inst = this._instances.get(instanceId);
+    const entry = inst?.registry.get(port);
     if (!entry) {
       this.channel?.port1.postMessage({
         type: "stream-start",
@@ -506,11 +831,13 @@ export class RequestProxy extends EventEmitter {
 
   // ---- WebSocket bridge ----
 
-  private _wsBridge: BroadcastChannel | null = null;
-  private _wsConns = new Map<
-    string,
-    { socket: import("./polyfills/net").TcpSocket; cleanup: () => void }
-  >();
+  /** mint a ws bridge token if the instance doesn't have one yet */
+  private _ensureWsTokenForInstance(instanceId: string): void {
+    const inst = this._getOrCreateInstance(instanceId);
+    if (!inst.wsBridgeToken) {
+      inst.wsBridgeToken = crypto.randomUUID();
+    }
+  }
 
   // listens on BroadcastChannel "nodepod-ws" for connect/send/close from preview
   // iframes, dispatches WS upgrade events on the virtual server, relays frames.
@@ -518,35 +845,37 @@ export class RequestProxy extends EventEmitter {
     if (typeof BroadcastChannel === "undefined") return;
     if (this._wsBridge) return;
 
-    this._wsBridgeToken = crypto.randomUUID();
-
     this._wsBridge = new BroadcastChannel("nodepod-ws");
     this._wsBridge.onmessage = (ev: MessageEvent) => {
       const d = ev.data;
       if (!d || !d.kind) return;
 
-      // check token
-      if (this._wsBridgeToken && d.token !== this._wsBridgeToken) return;
+      // validate against the instance-specific token
+      const instanceId: string = d.instanceId || DEFAULT_INSTANCE;
+      const inst = this._instances.get(instanceId);
+      if (!inst) return;
+      if (inst.wsBridgeToken && d.token !== inst.wsBridgeToken) return;
 
       if (d.kind === "ws-connect") {
-        this._handleWsConnect(d.uid, d.port, d.path, d.protocols);
+        this._handleWsConnect(instanceId, d.uid, d.port, d.path, d.protocols);
       } else if (d.kind === "ws-send") {
-        this._handleWsSend(d.uid, d.data, d.type);
+        this._handleWsSend(instanceId, d.uid, d.data, d.type);
       } else if (d.kind === "ws-close") {
-        this._handleWsClose(d.uid, d.code, d.reason);
+        this._handleWsClose(instanceId, d.uid, d.code, d.reason);
       }
     };
-
-    // Send the WS bridge token to the Service Worker so it can embed it in the WS shim
-    this._sendWsTokenToSW();
   }
 
   private _handleWsConnect(
+    instanceId: string,
     uid: string,
     port: number,
     path: string,
     protocols?: string,
   ): void {
+    const inst = this._instances.get(instanceId);
+    if (!inst) return;
+
     const server = getServer(port);
 
     const wsKey = btoa(
@@ -562,26 +891,33 @@ export class RequestProxy extends EventEmitter {
     };
     if (protocols) headers["sec-websocket-protocol"] = protocols;
 
-    // no local server -- try routing through ProcessManager (worker mode)
+    // no local server, try the instance's process manager (worker mode)
     if (!server) {
-      if (this._processManager) {
-        const pid = this._processManager.dispatchWsUpgrade(port, uid, path || "/", headers);
+      if (inst.processManager) {
+        const pid = inst.processManager.dispatchWsUpgrade(
+          port,
+          uid,
+          path || "/",
+          headers,
+        );
         if (pid >= 0) {
-          this._workerWsConns.set(uid, { pid });
+          inst.workerWsConns.set(uid, { pid });
           return;
         }
       }
       this._wsBridge?.postMessage({
         kind: "ws-error",
+        instanceId,
         uid,
         message: `No server on port ${port}`,
-        token: this._wsBridgeToken,
+        token: inst.wsBridgeToken,
       });
       return;
     }
 
     const { socket } = server.dispatchUpgrade(path || "/", headers);
     const bridge = this._wsBridge!;
+    const token = inst.wsBridgeToken;
 
     let outboundBuf = new Uint8Array(0);
     let handshakeDone = false;
@@ -600,7 +936,7 @@ export class RequestProxy extends EventEmitter {
         const text = new TextDecoder().decode(raw);
         if (text.startsWith("HTTP/1.1 101")) {
           handshakeDone = true;
-          bridge.postMessage({ kind: "ws-open", uid, token: this._wsBridgeToken });
+          bridge.postMessage({ kind: "ws-open", instanceId, uid, token });
           if (fn) queueMicrotask(() => fn(null));
           return true;
         }
@@ -621,20 +957,22 @@ export class RequestProxy extends EventEmitter {
             const text = new TextDecoder().decode(frame.data);
             bridge.postMessage({
               kind: "ws-message",
+              instanceId,
               uid,
               data: text,
               type: "text",
-              token: this._wsBridgeToken,
+              token,
             });
             break;
           }
           case WS_OPCODE.BINARY:
             bridge.postMessage({
               kind: "ws-message",
+              instanceId,
               uid,
               data: Array.from(frame.data),
               type: "binary",
-              token: this._wsBridgeToken,
+              token,
             });
             break;
           case WS_OPCODE.CLOSE: {
@@ -642,7 +980,13 @@ export class RequestProxy extends EventEmitter {
               frame.data.length >= 2
                 ? (frame.data[0] << 8) | frame.data[1]
                 : 1000;
-            bridge.postMessage({ kind: "ws-closed", uid, code, token: this._wsBridgeToken });
+            bridge.postMessage({
+              kind: "ws-closed",
+              instanceId,
+              uid,
+              code,
+              token,
+            });
             break;
           }
           case WS_OPCODE.PING:
@@ -661,42 +1005,75 @@ export class RequestProxy extends EventEmitter {
       outboundBuf = new Uint8Array(0);
       try { socket.destroy(); } catch { /* */ }
     };
-    this._wsConns.set(uid, { socket, cleanup });
+    inst.wsConns.set(uid, { socket, cleanup });
   }
 
-  private _handleWorkerWsFrame(msg: any): void {
+  private _handleWorkerWsFrame(instanceId: string, msg: any): void {
     const bridge = this._wsBridge;
     if (!bridge) return;
+    const inst = this._instances.get(instanceId);
+    if (!inst) return;
     const uid = msg.uid;
+    const token = inst.wsBridgeToken;
 
     switch (msg.kind) {
       case "open":
-        bridge.postMessage({ kind: "ws-open", uid, token: this._wsBridgeToken });
+        bridge.postMessage({ kind: "ws-open", instanceId, uid, token });
         break;
       case "text":
-        bridge.postMessage({ kind: "ws-message", uid, data: msg.data, type: "text", token: this._wsBridgeToken });
+        bridge.postMessage({
+          kind: "ws-message",
+          instanceId,
+          uid,
+          data: msg.data,
+          type: "text",
+          token,
+        });
         break;
       case "binary":
-        bridge.postMessage({ kind: "ws-message", uid, data: msg.bytes, type: "binary", token: this._wsBridgeToken });
+        bridge.postMessage({
+          kind: "ws-message",
+          instanceId,
+          uid,
+          data: msg.bytes,
+          type: "binary",
+          token,
+        });
         break;
       case "close":
-        bridge.postMessage({ kind: "ws-closed", uid, code: msg.code || 1000, token: this._wsBridgeToken });
-        this._workerWsConns.delete(uid);
+        bridge.postMessage({
+          kind: "ws-closed",
+          instanceId,
+          uid,
+          code: msg.code || 1000,
+          token,
+        });
+        inst.workerWsConns.delete(uid);
         break;
       case "error":
-        bridge.postMessage({ kind: "ws-error", uid, message: msg.message, token: this._wsBridgeToken });
-        this._workerWsConns.delete(uid);
+        bridge.postMessage({
+          kind: "ws-error",
+          instanceId,
+          uid,
+          message: msg.message,
+          token,
+        });
+        inst.workerWsConns.delete(uid);
         break;
     }
   }
 
   private _handleWsSend(
+    instanceId: string,
     uid: string,
     data: unknown,
     type?: string,
   ): void {
-    const workerConn = this._workerWsConns.get(uid);
-    if (workerConn && this._processManager) {
+    const inst = this._instances.get(instanceId);
+    if (!inst) return;
+
+    const workerConn = inst.workerWsConns.get(uid);
+    if (workerConn && inst.processManager) {
       let payload: Uint8Array;
       let op: number;
       if (type === "binary" && Array.isArray(data)) {
@@ -707,11 +1084,15 @@ export class RequestProxy extends EventEmitter {
         op = WS_OPCODE.TEXT;
       }
       const frame = encodeFrame(op, payload, true);
-      this._processManager.dispatchWsData(workerConn.pid, uid, Array.from(new Uint8Array(frame)));
+      inst.processManager.dispatchWsData(
+        workerConn.pid,
+        uid,
+        Array.from(new Uint8Array(frame)),
+      );
       return;
     }
 
-    const conn = this._wsConns.get(uid);
+    const conn = inst.wsConns.get(uid);
     if (!conn) return;
 
     let payload: Uint8Array;
@@ -727,15 +1108,23 @@ export class RequestProxy extends EventEmitter {
     conn.socket._feedData(Buffer.from(frame));
   }
 
-  private _handleWsClose(uid: string, code?: number, reason?: string): void {
-    const workerConn = this._workerWsConns.get(uid);
-    if (workerConn && this._processManager) {
-      this._processManager.dispatchWsClose(workerConn.pid, uid, code ?? 1000);
-      this._workerWsConns.delete(uid);
+  private _handleWsClose(
+    instanceId: string,
+    uid: string,
+    code?: number,
+    _reason?: string,
+  ): void {
+    const inst = this._instances.get(instanceId);
+    if (!inst) return;
+
+    const workerConn = inst.workerWsConns.get(uid);
+    if (workerConn && inst.processManager) {
+      inst.processManager.dispatchWsClose(workerConn.pid, uid, code ?? 1000);
+      inst.workerWsConns.delete(uid);
       return;
     }
 
-    const conn = this._wsConns.get(uid);
+    const conn = inst.wsConns.get(uid);
     if (!conn) return;
 
     const codeBuf = new Uint8Array(2);
@@ -745,7 +1134,7 @@ export class RequestProxy extends EventEmitter {
     try { conn.socket._feedData(Buffer.from(frame)); } catch { /* */ }
 
     conn.cleanup();
-    this._wsConns.delete(uid);
+    inst.wsConns.delete(uid);
   }
 
   private notifySW(type: string, data: unknown): void {
@@ -756,11 +1145,37 @@ export class RequestProxy extends EventEmitter {
   createFetchHandler(): (req: Request) => Promise<Response> {
     return async (req: Request): Promise<Response> => {
       const parsed = new URL(req.url);
-      const match = parsed.pathname.match(/^\/__virtual__\/(\d+)(\/.*)?$/);
-      if (!match) throw new Error("Not a virtual server request");
+      // /__virtual__/{instanceId}/{port}/... or legacy /__virtual__/{port}/...
+      // new form requires at least one non-digit char in the first segment
+      const newMatch = parsed.pathname.match(
+        /^\/__virtual__\/([^/]+)\/(\d+)(\/.*)?$/,
+      );
+      const oldMatch =
+        !newMatch &&
+        parsed.pathname.match(/^\/__virtual__\/(\d+)(\/.*)?$/);
 
-      const port = parseInt(match[1], 10);
-      const path = match[2] || "/";
+      let instanceId: string;
+      let port: number;
+      let path: string;
+      if (newMatch) {
+        // all-digits first segment means the old form with a swallowed slash
+        if (/^\d+$/.test(newMatch[1])) {
+          instanceId = DEFAULT_INSTANCE;
+          port = parseInt(newMatch[1], 10);
+          path = (newMatch[2] ? "/" + newMatch[2] : "/") + (newMatch[3] || "");
+        } else {
+          instanceId = newMatch[1];
+          port = parseInt(newMatch[2], 10);
+          path = newMatch[3] || "/";
+        }
+      } else if (oldMatch) {
+        instanceId = DEFAULT_INSTANCE;
+        port = parseInt(oldMatch[1], 10);
+        path = oldMatch[2] || "/";
+      } else {
+        throw new Error("Not a virtual server request");
+      }
+
       const hdrs: Record<string, string> = {};
       req.headers.forEach((v, k) => {
         hdrs[k] = v;
@@ -770,6 +1185,7 @@ export class RequestProxy extends EventEmitter {
         reqBody = await req.arrayBuffer();
 
       const resp = await this.handleRequest(
+        instanceId,
         port,
         req.method,
         path + parsed.search,

--- a/src/sdk/nodepod.ts
+++ b/src/sdk/nodepod.ts
@@ -34,8 +34,22 @@ import { SyncChannelController } from "../threading/sync-channel";
 import { MemoryHandler } from "../memory-handler";
 import { openSnapshotCache } from "../persistence/idb-cache";
 
+// short url-safe id. always starts with a letter so it can't be confused
+// with a port number in /__virtual__/{id}/{port}
+function makeInstanceId(): string {
+  const rand =
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID().replace(/-/g, "").slice(0, 8)
+      : Math.random().toString(36).slice(2, 10);
+  return "pod" + rand;
+}
+
 export class Nodepod {
   readonly fs: NodepodFS;
+
+  /** unique id used by RequestProxy + SW to route back to this Nodepod when
+   *  multiple coexist on one page */
+  readonly instanceId: string;
 
   private _volume: MemoryVolume;
   private _packages: DependencyInstaller;
@@ -61,6 +75,7 @@ export class Nodepod {
     handler: MemoryHandler,
     env: Record<string, string>,
     sabEnabled: boolean,
+    instanceId: string,
   ) {
     this._volume = volume;
     this._packages = packages;
@@ -69,6 +84,7 @@ export class Nodepod {
     this._env = env;
     this._handler = handler;
     this._sabEnabled = sabEnabled;
+    this.instanceId = instanceId;
     this.fs = new NodepodFS(volume);
     this._processManager = new ProcessManager(volume);
     this._vfsBridge = new VFSBridge(volume);
@@ -146,15 +162,15 @@ export class Nodepod {
             };
           },
         };
-        this._proxy.register(proxyServer, port);
+        this._proxy.register(this.instanceId, proxyServer, port);
       },
     );
 
     this._processManager.on("server-close", (_pid: number, port: number) => {
-      this._proxy.unregister(port);
+      this._proxy.unregister(this.instanceId, port);
     });
 
-    this._proxy.setProcessManager(this._processManager);
+    this._proxy.attach(this.instanceId, this._processManager);
   }
 
   /* ---- Static factory ---- */
@@ -217,6 +233,7 @@ export class Nodepod {
       handler,
       env,
       sabEnabled,
+      makeInstanceId(),
     );
 
     if (opts.files) {
@@ -595,19 +612,20 @@ export class Nodepod {
   // Useful for setting up a communication bridge between the main window and
   // the preview iframe, injecting polyfills, analytics, etc.
   async setPreviewScript(script: string): Promise<void> {
-    this._proxy.setPreviewScript(script);
+    this._proxy.setPreviewScript(this.instanceId, script);
   }
 
   async clearPreviewScript(): Promise<void> {
-    this._proxy.setPreviewScript(null);
+    this._proxy.setPreviewScript(this.instanceId, null);
   }
 
   /* ---- port() ---- */
 
-  // Returns the preview URL for a server on this port, or null
+  // preview url for a server on this port, or null. scoped to instanceId so
+  // multiple Nodepods on one page don't collide
   port(num: number): string | null {
-    if (this._proxy.activePorts().includes(num)) {
-      return this._proxy.serverUrl(num);
+    if (this._proxy.activePorts(this.instanceId).includes(num)) {
+      return this._proxy.serverUrl(this.instanceId, num);
     }
     return null;
   }
@@ -648,6 +666,12 @@ export class Nodepod {
     if (this._unwatchVFS) {
       this._unwatchVFS();
       this._unwatchVFS = null;
+    }
+    // release our slot so sibling Nodepods on the same page keep working
+    try {
+      this._proxy.detach(this.instanceId);
+    } catch {
+      /* */
     }
     this._processManager.teardown();
     this._volume.dispose();

--- a/static/__sw__.js
+++ b/static/__sw__.js
@@ -1,39 +1,161 @@
 /**
- * Nodepod Service Worker — proxies requests to virtual servers.
- * Version: 2 (cross-origin passthrough + prefix stripping)
+ * Nodepod Service Worker - proxies requests to virtual servers.
+ * Version: 8 (multi-tab)
  *
  * Intercepts:
- *   /__virtual__/{port}/{path}  — virtual server API
- *   /__preview__/{port}/{path}  — preview iframe navigation
- *   Any request from a client loaded via /__preview__/ — module imports etc.
+ *   /__virtual__/{instanceId}/{port}/{path}  virtual server API (new)
+ *   /__preview__/{instanceId}/{port}/{path}  preview iframe navigation (new)
+ *   /__virtual__/{port}/{path}               legacy, routes to DEFAULT_INSTANCE
+ *   /__preview__/{port}/{path}               legacy, routes to DEFAULT_INSTANCE
+ *   Any request from a client loaded via /__preview__/ (module imports etc)
  *
- * When an iframe navigates to /__preview__/{port}/, the SW records the
- * resulting clientId. All subsequent requests from that client (including
- * ES module imports like /@react-refresh) are intercepted and routed
- * through the virtual server.
+ * When an iframe navigates to /__preview__/{instanceId}/{port}/, the SW records
+ * the resulting clientId with its (instanceId, port). All subsequent requests
+ * from that client (including ES module imports like /@react-refresh) are
+ * intercepted and routed through the right instance's virtual server.
+ *
+ * Multi-tab: one SW serves every tab at this scope, but each tab has its own
+ * RequestProxy and its own MessageChannel. we hold a map of MessagePorts
+ * (one per tab) and route each fetch to whichever port claimed the fetch's
+ * instanceId. without this a second tab's init would overwrite the first
+ * tab's port and you'd get "No server on {instanceId}/{port}" 503s.
  */
 
-const SW_VERSION = 6;
+const SW_VERSION = 8;
+const DEFAULT_INSTANCE = "default";
 
-let port = null;
 let nextId = 1;
+// id -> { resolve, reject, port }
 const pending = new Map();
 
-// Maps clientId -> serverPort for preview iframes
+// one entry per connected tab. MessagePort -> { token, instances: Set<string> }
+const ports = new Map();
+
+// routing table for fetches. instanceId -> MessagePort
+const instancePorts = new Map();
+
+// clientId -> { instanceId, serverPort } for preview iframes
 const previewClients = new Map();
 
-// User-injected script that runs before any page content in preview iframes.
-// Set via postMessage({ type: "set-preview-script", script: "..." }) from main thread.
-let previewScript = null;
+// per-instance script injected into preview iframe HTML
+const previewScripts = new Map();
 
-// Watermark badge shown in preview iframes. On by default.
+// global watermark toggle, last writer across tabs wins
 let watermarkEnabled = true;
 
-// auth token from init, checked on control messages
-let authToken = null;
+// per-instance ws bridge tokens
+const wsTokens = new Map();
 
-// ws bridge token, gets baked into the shim script
-let wsToken = null;
+// any token from any currently connected tab is accepted. used for control
+// messages that aren't tied to a specific instance (set-watermark etc)
+function isValidToken(t) {
+  if (!t) return false;
+  for (const info of ports.values()) {
+    if (info.token === t) return true;
+  }
+  return false;
+}
+
+// for per-instance messages the token must match the tab that claimed the
+// instance. if no one claimed it yet any valid token passes
+function isValidTokenForInstance(token, instanceId) {
+  const mp = instancePorts.get(instanceId);
+  if (mp) {
+    const info = ports.get(mp);
+    return info ? info.token === token : false;
+  }
+  return isValidToken(token);
+}
+
+// exact match first, then fall back to whoever owns DEFAULT_INSTANCE (legacy
+// single-tenant callers), then any connected port
+function getPortForInstance(instanceId) {
+  const mp = instancePorts.get(instanceId);
+  if (mp) return mp;
+  const def = instancePorts.get(DEFAULT_INSTANCE);
+  if (def) return def;
+  if (ports.size > 0) return ports.keys().next().value;
+  return null;
+}
+
+function claimInstance(mp, instanceId) {
+  if (!mp || !ports.has(mp)) return;
+  instancePorts.set(instanceId, mp);
+  ports.get(mp).instances.add(instanceId);
+}
+
+// only release if this port still owns it. a newer tab may have reclaimed it
+function releaseInstance(mp, instanceId) {
+  if (instancePorts.get(instanceId) === mp) {
+    instancePorts.delete(instanceId);
+    previewScripts.delete(instanceId);
+    wsTokens.delete(instanceId);
+  }
+  const info = ports.get(mp);
+  if (info) info.instances.delete(instanceId);
+}
+
+// drop every reference to a port so stale entries don't route fetches nowhere
+function cleanupPort(mp) {
+  const info = ports.get(mp);
+  if (info) {
+    for (const id of info.instances) {
+      if (instancePorts.get(id) === mp) {
+        instancePorts.delete(id);
+        previewScripts.delete(id);
+        wsTokens.delete(id);
+      }
+    }
+  }
+  ports.delete(mp);
+}
+
+// Extract (instanceId, port, restPath) from a /__virtual__/... or /__preview__/... pathname.
+// Returns null if no match. Handles both the new 3-segment form and the legacy
+// 2-segment form (falls back to DEFAULT_INSTANCE).
+function matchPreviewOrVirtualPath(pathname, kind /* "virtual" | "preview" */) {
+  const prefix = kind === "virtual" ? "__virtual__" : "__preview__";
+  // New: /__{kind}__/{instanceId}/{port}[/rest]
+  // Require non-digit in first segment so we don't swallow legacy ports.
+  const newRe = new RegExp(
+    "^\\/" + prefix + "\\/([A-Za-z0-9_-]*[A-Za-z_-][A-Za-z0-9_-]*)\\/(\\d+)(\\/.*)?$"
+  );
+  const m1 = pathname.match(newRe);
+  if (m1) {
+    return {
+      instanceId: m1[1],
+      port: parseInt(m1[2], 10),
+      rest: m1[3] || "/",
+    };
+  }
+  // Legacy: /__{kind}__/{port}[/rest]
+  const oldRe = new RegExp("^\\/" + prefix + "\\/(\\d+)(\\/.*)?$");
+  const m2 = pathname.match(oldRe);
+  if (m2) {
+    return {
+      instanceId: DEFAULT_INSTANCE,
+      port: parseInt(m2[1], 10),
+      rest: m2[2] || "/",
+    };
+  }
+  return null;
+}
+
+// Strip the /__{kind}__/{instanceId}/{port} or /__{kind}__/{port} prefix from
+// a pathname when a client was loaded via a preview URL and the browser
+// resolved a relative URL against it. Returns the unprefixed path or the
+// original if no prefix was found.
+function stripPreviewPrefix(pathname) {
+  const m = pathname.match(
+    /^\/__(?:preview|virtual)__\/(?:[A-Za-z0-9_-]*[A-Za-z_-][A-Za-z0-9_-]*\/\d+|\d+)(\/.*)?$/
+  );
+  if (m) {
+    let stripped = m[1] || "/";
+    if (stripped[0] !== "/") stripped = "/" + stripped;
+    return stripped;
+  }
+  return pathname;
+}
 
 // Standard MIME types by file extension — used as a safety net when
 // the virtual server returns text/html (SPA fallback) or omits Content-Type
@@ -116,46 +238,115 @@ self.addEventListener("activate", (event) => {
 
 self.addEventListener("message", (event) => {
   const data = event.data;
+  if (!data) return;
 
-  // init sets up the port + grabs the auth token
-  if (data?.type === "init" && data.port) {
-    port = data.port;
-    port.onmessage = onPortMessage;
-    if (data.token) {
-      authToken = data.token;
+  // register a new tab's MessagePort. if the same tab reinits (same token,
+  // new channel from controllerchange) drop the old port first so stale
+  // entries don't accumulate. RequestProxy resends claim-instance after.
+  if (data.type === "init" && data.port) {
+    const mp = data.port;
+    const token = data.token || null;
+    if (token) {
+      for (const [old, info] of [...ports.entries()]) {
+        if (old !== mp && info.token === token) {
+          cleanupPort(old);
+        }
+      }
+    }
+    ports.set(mp, { token, instances: new Set() });
+    mp.onmessage = (ev) => onPortMessage(ev, mp);
+
+    // claim uncontrolled clients now. the activate event's clients.claim()
+    // only covers fresh install, it does NOT cover hard refresh (Ctrl+Shift+R)
+    // of a page that already had this SW registered, the browser bypasses the
+    // SW for the top-level nav and the page stays uncontrolled forever since
+    // activate doesn't re-run. reclaiming here fires controllerchange on that
+    // page so its fetches route through the SW like normal.
+    if (event.waitUntil) {
+      event.waitUntil(self.clients.claim());
+    } else {
+      self.clients.claim();
     }
     return;
   }
 
-  // everything else needs the right token
-  if (authToken && data?.token !== authToken) return;
+  // everything else requires a token from some live tab
+  if (!isValidToken(data.token)) return;
 
-  // Allow main thread to register/unregister preview clients
-  if (data?.type === "register-preview") {
-    previewClients.set(data.clientId, data.serverPort);
+  if (data.type === "register-preview") {
+    previewClients.set(data.clientId, {
+      instanceId: data.instanceId || DEFAULT_INSTANCE,
+      serverPort: data.serverPort,
+    });
+    return;
   }
-  if (data?.type === "unregister-preview") {
+  if (data.type === "unregister-preview") {
     previewClients.delete(data.clientId);
+    return;
   }
-  if (data?.type === "set-preview-script") {
-    previewScript = data.script ?? null;
+  if (data.type === "set-preview-script") {
+    const id = data.instanceId || DEFAULT_INSTANCE;
+    if (!isValidTokenForInstance(data.token, id)) return;
+    if (data.script === null || data.script === undefined) {
+      previewScripts.delete(id);
+    } else {
+      previewScripts.set(id, data.script);
+    }
+    return;
   }
-  if (data?.type === "set-watermark") {
+  if (data.type === "set-watermark") {
     watermarkEnabled = !!data.enabled;
+    return;
   }
-  if (data?.type === "set-ws-token") {
-    wsToken = data.wsToken ?? null;
+  if (data.type === "set-ws-token") {
+    const id = data.instanceId || DEFAULT_INSTANCE;
+    if (!isValidTokenForInstance(data.token, id)) return;
+    if (data.wsToken === null || data.wsToken === undefined) {
+      wsTokens.delete(id);
+    } else {
+      wsTokens.set(id, data.wsToken);
+    }
+    return;
   }
 });
 
-function onPortMessage(event) {
+// messages over a tab's MessagePort. mp is captured at init time so we always
+// know which tab spoke
+function onPortMessage(event, mp) {
   const msg = event.data;
+  if (!msg) return;
+
   if (msg.type === "response" && pending.has(msg.id)) {
     const { resolve, reject } = pending.get(msg.id);
     pending.delete(msg.id);
     if (msg.error) reject(new Error(msg.error));
     else resolve(msg.data);
+    return;
   }
+
+  if (msg.type === "claim-instance" && msg.data && msg.data.instanceId) {
+    claimInstance(mp, msg.data.instanceId);
+    return;
+  }
+  if (msg.type === "release-instance" && msg.data && msg.data.instanceId) {
+    releaseInstance(mp, msg.data.instanceId);
+    return;
+  }
+  if (msg.type === "release-all") {
+    cleanupPort(mp);
+    return;
+  }
+
+  // server-registered implicitly claims the instance so legacy callers that
+  // never sent claim-instance still route correctly
+  if (msg.type === "server-registered" && msg.data && msg.data.instanceId) {
+    claimInstance(mp, msg.data.instanceId);
+    return;
+  }
+  // note: server-unregistered does NOT release. a tab may register multiple
+  // servers for one instance and we only want to unclaim on explicit release
+
+  if (msg.type === "keepalive") return;
 }
 
 // ── Fetch interception ──
@@ -163,104 +354,97 @@ function onPortMessage(event) {
 self.addEventListener("fetch", (event) => {
   const url = new URL(event.request.url);
 
-  // 1. explicit /__virtual__/{port}/{path} — navigating an iframe here (the URL
-  //    request-proxy.serverUrl() returns) must also register the resulting
-  //    clientId, else absolute-path module imports from the HTML (e.g.
-  //    /@vite/client, /src/main.tsx) miss every branch below and hit the host
-  const virtualMatch = url.pathname.match(/^\/__virtual__\/(\d+)(\/.*)?$/);
-  if (virtualMatch) {
-    const serverPort = parseInt(virtualMatch[1], 10);
-    const path = (virtualMatch[2] || "/") + url.search;
+  // 1. explicit /__virtual__/{instanceId}/{port}/{path} or legacy /__virtual__/{port}/{path}
+  const virtualHit = matchPreviewOrVirtualPath(url.pathname, "virtual");
+  if (virtualHit) {
+    const { instanceId, port: serverPort, rest } = virtualHit;
+    const path = rest + url.search;
     if (event.request.mode === "navigate") {
       event.respondWith(
         (async () => {
           if (event.resultingClientId) {
-            previewClients.set(event.resultingClientId, serverPort);
+            previewClients.set(event.resultingClientId, { instanceId, serverPort });
           }
-          return proxyToVirtualServer(event.request, serverPort, path);
+          return proxyToVirtualServer(event.request, instanceId, serverPort, path);
         })(),
       );
     } else {
-      event.respondWith(proxyToVirtualServer(event.request, serverPort, path));
+      event.respondWith(
+        proxyToVirtualServer(event.request, instanceId, serverPort, path),
+      );
     }
     return;
   }
 
-  // 2. Explicit /__preview__/{port}/{path} — navigation or subresource
-  const previewMatch = url.pathname.match(/^\/__preview__\/(\d+)(\/.*)?$/);
-  if (previewMatch) {
-    const serverPort = parseInt(previewMatch[1], 10);
-    const path = (previewMatch[2] || "/") + url.search;
+  // 2. Explicit /__preview__/{instanceId}/{port}/{path} or legacy /__preview__/{port}/{path}
+  const previewHit = matchPreviewOrVirtualPath(url.pathname, "preview");
+  if (previewHit) {
+    const { instanceId, port: serverPort, rest } = previewHit;
+    const path = rest + url.search;
 
-    // Track the resulting client (for navigation requests) or current client
     if (event.request.mode === "navigate") {
       event.respondWith(
         (async () => {
-          // resultingClientId is the client that will be created by this navigation
           if (event.resultingClientId) {
-            previewClients.set(event.resultingClientId, serverPort);
+            previewClients.set(event.resultingClientId, { instanceId, serverPort });
           }
-          return proxyToVirtualServer(event.request, serverPort, path);
+          return proxyToVirtualServer(event.request, instanceId, serverPort, path);
         })(),
       );
     } else {
-      event.respondWith(proxyToVirtualServer(event.request, serverPort, path));
+      event.respondWith(
+        proxyToVirtualServer(event.request, instanceId, serverPort, path),
+      );
     }
     return;
   }
 
-  // 3. Request from a tracked preview client — route through virtual server.
-  //    This catches module imports like /@react-refresh, /src/main.tsx, etc.
-  //    Only intercept same-origin requests; let cross-origin requests
-  //    (e.g. Google Fonts, external CDNs) pass through to the real server.
+  // 3. request from a tracked preview client, route through that instance's
+  //    virtual server. catches module imports like /@react-refresh etc.
+  //    only same-origin, let cross-origin (google fonts, CDNs) pass through
   const clientId = event.clientId;
   if (clientId && previewClients.has(clientId)) {
     const host = url.hostname;
     if (host === "localhost" || host === "127.0.0.1" || host === "0.0.0.0" || host === self.location.hostname) {
-      const serverPort = previewClients.get(clientId);
-      // strip /__preview__/{port} or /__virtual__/{port} prefix if the browser
-      // resolved a relative URL against the preview page's location
-      // (e.g. /__preview__/3001.rsc → /.rsc, /__virtual__/3001/foo → /foo)
-      let path = url.pathname;
-      const ppMatch = path.match(/^\/__(?:preview|virtual)__\/\d+(.*)?$/);
-      if (ppMatch) {
-        path = ppMatch[1] || "/";
-        if (path[0] !== "/") path = "/" + path;
-      }
+      const { instanceId, serverPort } = previewClients.get(clientId);
+      // strip /__preview__/{instanceId}/{port} or /__virtual__/{instanceId}/{port}
+      // (or legacy forms) if the browser resolved a relative URL against the
+      // preview page's location.
+      let path = stripPreviewPrefix(url.pathname);
       path += url.search;
-      event.respondWith(proxyToVirtualServer(event.request, serverPort, path, event.request));
+      event.respondWith(
+        proxyToVirtualServer(event.request, instanceId, serverPort, path, event.request),
+      );
       return;
     }
   }
 
-  // 4. fallback: check Referer header for /__preview__/ or /__virtual__/ prefix.
-  //    handles the Firefox race where the first subresource after a navigation
-  //    arrives with event.clientId === "" (before the new client is registered).
-  //    covers either URL style since both are valid entry points. only intercept
-  //    same-origin requests (not cross-origin like Google Fonts)
+  // 4. fallback: check Referer header. Handles the Firefox race where the first
+  //    subresource after a navigation arrives with event.clientId === "".
   const referer = event.request.referrer;
   if (referer) {
     try {
       const refUrl = new URL(referer);
-      const refMatch = refUrl.pathname.match(/^\/__(?:preview|virtual)__\/(\d+)/);
-      if (refMatch) {
+      // Try new then legacy shape in the referer path
+      const refHit =
+        matchPreviewOrVirtualPath(refUrl.pathname, "preview") ||
+        matchPreviewOrVirtualPath(refUrl.pathname, "virtual");
+      if (refHit) {
         const host = url.hostname;
-        if (host === "localhost" || host === "127.0.0.1" || host === "0.0.0.0" || host === self.location.hostname) {
-          const serverPort = parseInt(refMatch[1], 10);
-          // strip /__preview__/{port} or /__virtual__/{port} prefix if present
-          let path = url.pathname;
-          const ppMatch2 = path.match(/^\/__(?:preview|virtual)__\/\d+(.*)?$/);
-          if (ppMatch2) {
-            path = ppMatch2[1] || "/";
-            if (path[0] !== "/") path = "/" + path;
-          }
+        if (
+          host === "localhost" ||
+          host === "127.0.0.1" ||
+          host === "0.0.0.0" ||
+          host === self.location.hostname
+        ) {
+          const { instanceId, port: serverPort } = refHit;
+          let path = stripPreviewPrefix(url.pathname);
           path += url.search;
-          // Also register this client for future requests
           if (clientId) {
-            previewClients.set(clientId, serverPort);
+            previewClients.set(clientId, { instanceId, serverPort });
           }
           event.respondWith(
-            proxyToVirtualServer(event.request, serverPort, path, event.request),
+            proxyToVirtualServer(event.request, instanceId, serverPort, path, event.request),
           );
           return;
         }
@@ -280,8 +464,10 @@ self.addEventListener("fetch", (event) => {
 // to the main thread's request-proxy, which dispatches upgrade events on the
 // virtual HTTP server. Works with any framework/library, not specific to Vite.
 
-function getWsShimScript() {
-  const tokenStr = wsToken ? JSON.stringify(wsToken) : "null";
+function getWsShimScript(instanceId) {
+  const token = wsTokens.get(instanceId);
+  const tokenStr = token ? JSON.stringify(token) : "null";
+  const instanceIdStr = JSON.stringify(instanceId);
   return `<script>
 (function() {
   if (window.__nodepodWsShim) return;
@@ -289,17 +475,18 @@ function getWsShimScript() {
   var NativeWS = window.WebSocket;
   var bc = new BroadcastChannel("nodepod-ws");
   var _wsToken = ${tokenStr};
+  var _instanceId = ${instanceIdStr};
   var nextId = 0;
   var active = {};
 
-  // detect the virtual server port from the page URL.
-  // when loaded via /__preview__/{port}/ or /__virtual__/{port}/, use that port
-  // for WS connections instead of the literal port from the WS URL (which may
-  // be the host page's port, not the virtual server's port)
+  // detect the virtual server port from the page URL. When loaded via
+  // /__preview__/{instanceId}/{port}/ or /__virtual__/{instanceId}/{port}/,
+  // use that port for WS connections instead of the literal port from the
+  // WS URL (which may be the host page's port, not the virtual server's).
   var _previewPort = 0;
   try {
-    var _m = location.pathname.match(/^\\/__(?:preview|virtual)__\\/(\\d+)/);
-    if (_m) _previewPort = parseInt(_m[1], 10);
+    var _m = location.pathname.match(/^\\/__(?:preview|virtual)__\\/(?:[A-Za-z0-9_-]*[A-Za-z_-][A-Za-z0-9_-]*\\/(\\d+)|(\\d+))/);
+    if (_m) _previewPort = parseInt(_m[1] || _m[2], 10);
   } catch(e) {}
 
   function NodepodWS(url, protocols) {
@@ -314,7 +501,7 @@ function getWsShimScript() {
     }
     var self = this;
     var uid = "ws-iframe-" + (++nextId) + "-" + Math.random().toString(36).slice(2,8);
-    // Use the preview port (from /__preview__/{port}/) if available,
+    // Use the preview port (from /__preview__/.../{port}/) if available,
     // otherwise fall back to the port from the WebSocket URL.
     var port = _previewPort || parseInt(parsed.port) || (parsed.protocol === "wss:" ? 443 : 80);
     var path = parsed.pathname + parsed.search;
@@ -336,6 +523,7 @@ function getWsShimScript() {
 
     bc.postMessage({
       kind: "ws-connect",
+      instanceId: _instanceId,
       uid: uid,
       port: port,
       path: path,
@@ -387,12 +575,12 @@ function getWsShimScript() {
       type = "binary";
       payload = Array.from(data);
     }
-    bc.postMessage({ kind: "ws-send", uid: this._uid, data: payload, type: type, token: _wsToken });
+    bc.postMessage({ kind: "ws-send", instanceId: _instanceId, uid: this._uid, data: payload, type: type, token: _wsToken });
   };
   NodepodWS.prototype.close = function(code, reason) {
     if (this.readyState >= 2) return;
     this.readyState = 2;
-    bc.postMessage({ kind: "ws-close", uid: this._uid, code: code || 1000, reason: reason || "", token: _wsToken });
+    bc.postMessage({ kind: "ws-close", instanceId: _instanceId, uid: this._uid, code: code || 1000, reason: reason || "", token: _wsToken });
     var self = this;
     setTimeout(function() {
       self.readyState = 3;
@@ -415,6 +603,8 @@ function getWsShimScript() {
   bc.onmessage = function(ev) {
     var d = ev.data;
     if (!d || !d.uid) return;
+    // Filter by instance so a sibling Nodepod's chatter doesn't leak in
+    if (d.instanceId && d.instanceId !== _instanceId) return;
     // check bridge token
     if (_wsToken && d.token !== _wsToken) return;
     var ws = active[d.uid];
@@ -527,14 +717,19 @@ function errorPage(status, title, message) {
 
 // ── Virtual server proxy ──
 
-async function proxyToVirtualServer(request, serverPort, path, originalRequest) {
-  if (!port) {
+async function proxyToVirtualServer(request, instanceId, serverPort, path, originalRequest) {
+  // route to whichever tab owns this instanceId
+  let targetPort = getPortForInstance(instanceId);
+
+  if (!targetPort) {
+    // no tabs connected, poke clients to reinit and give them a moment
     const clients = await self.clients.matchAll();
     for (const client of clients) {
       client.postMessage({ type: "sw-needs-init" });
     }
     await new Promise((r) => setTimeout(r, 200));
-    if (!port) {
+    targetPort = getPortForInstance(instanceId);
+    if (!targetPort) {
       return errorPage(503, "Service Unavailable", "The Nodepod service worker is still initializing. Please refresh the page.");
     }
   }
@@ -560,31 +755,43 @@ async function proxyToVirtualServer(request, serverPort, path, originalRequest) 
 
   const id = nextId++;
   const promise = new Promise((resolve, reject) => {
-    pending.set(id, { resolve, reject });
+    pending.set(id, { resolve, reject, port: targetPort });
     setTimeout(() => {
       if (pending.has(id)) {
+        const entry = pending.get(id);
         pending.delete(id);
+        // port never answered, likely stale (tab closed without pagehide).
+        // evict so the next request doesn't waste another 30s on it
+        if (entry.port && ports.has(entry.port)) {
+          cleanupPort(entry.port);
+        }
         reject(new Error("Request timeout: " + path));
       }
     }, 30000);
   });
 
-  port.postMessage({
-    type: "request",
-    id,
-    data: {
-      port: serverPort,
-      method: request.method,
-      url: path,
-      headers,
-      body,
-      // Pass the full original URL so the main thread can do a fallback
-      // network fetch if the virtual server returns 404. This handles
-      // cross-origin resources (fonts, CDN assets) that the preview app
-      // references but the virtual server doesn't serve.
-      originalUrl: request.url,
-    },
-  });
+  try {
+    targetPort.postMessage({
+      type: "request",
+      id,
+      data: {
+        instanceId,
+        port: serverPort,
+        method: request.method,
+        url: path,
+        headers,
+        body,
+        // original url so main thread can fall back to a network fetch if
+        // the virtual server returns 404 (fonts, CDNs etc)
+        originalUrl: request.url,
+      },
+    });
+  } catch (err) {
+    // port got detached between lookup and post
+    pending.delete(id);
+    cleanupPort(targetPort);
+    return errorPage(503, "Service Unavailable", "The owning tab for this server is no longer connected.");
+  }
 
   try {
     const data = await promise;
@@ -614,7 +821,8 @@ async function proxyToVirtualServer(request, serverPort, path, originalRequest) 
     let finalBody = responseBody;
     const ct = respHeaders["content-type"] || respHeaders["Content-Type"] || "";
     if (ct.includes("text/html") && responseBody) {
-      let injection = getWsShimScript();
+      let injection = getWsShimScript(instanceId);
+      const previewScript = previewScripts.get(instanceId);
       if (previewScript) {
         injection += `<script>${previewScript}<` + `/script>`;
       }


### PR DESCRIPTION
one SW shared across tabs was blowing up in a few ways:

- each tab's init() overwrote the SW's global port so fetches for Tab A's instance landed on Tab B's RequestProxy and 503d with "No server on {id}/{port}". SW now keeps a MessagePort map per instanceId
- on chrome, unregister + reload left boot hanging forever because controllerchange doesnt fire after clients.claim(). swapped the register+statechange+ controllerchange dance for a single navigator.serviceWorker.ready plus a safety timeout
- ctrl+shift+r with an existing SW left the page uncontrolled forever on both browsers because the active SW never re-runs activate. SW now calls clients.claim() on every init message

also: attach/detach send claim-instance / release-instance, pagehide fires release-all so closed tabs drop their routing entries instead of timing out for 30s on the next fetch, examples/multi-boot-race reproducer, integration test for the multi-tenant paths