### PR TITLE
feat: add @xterm/addon-serialize integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "@xterm/xterm": "^6.0.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-webgl": "^0.19.0",
+    "@xterm/addon-serialize": "^0.14.0",
     "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
     "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
   },
@@ -114,6 +115,9 @@
       "optional": true
     },
     "@xterm/addon-webgl": {
+      "optional": true
+    },
+    "@xterm/addon-serialize": {
       "optional": true
     },
     "vite": {

--- a/src/sdk/nodepod-terminal.ts
+++ b/src/sdk/nodepod-terminal.ts
@@ -69,6 +69,8 @@ export interface TerminalWiring {
 export class NodepodTerminal {
   private _term: any = null;
   private _fitAddon: any = null;
+  private _serializeAddon: any = null;
+  private _serializedBuffer = "";
   private _dataDisposable: any = null;
   private _xtermResizeDisposable: any = null;
   private _resizeHandler: (() => void) | null = null;
@@ -151,7 +153,16 @@ export class NodepodTerminal {
       this._term.loadAddon(this._fitAddon);
     }
 
+    if (this._opts.SerializeAddon) {
+      this._serializeAddon = new this._opts.SerializeAddon();
+      this._term.loadAddon(this._serializeAddon);
+    }
+
     this._term.open(container);
+
+    if (this._serializedBuffer) {
+      this._term.write(this._serializedBuffer);
+    }
 
     if (this._opts.WebglAddon) {
       try {
@@ -232,6 +243,10 @@ export class NodepodTerminal {
       window.removeEventListener("resize", this._resizeHandler);
       this._resizeHandler = null;
     }
+    if (this._serializeAddon) {
+      this._serializedBuffer = this._serializeAddon.serialize();
+      this._serializeAddon = null;
+    }
     if (this._term) {
       this._term.dispose();
       this._term = null;
@@ -259,6 +274,13 @@ export class NodepodTerminal {
 
   fit(): void {
     this._fitAddon?.fit();
+  }
+
+  serialize(): string {
+    if (this._serializeAddon) {
+      return this._serializeAddon.serialize();
+    }
+    return this._serializedBuffer;
   }
 
   write(text: string): void {

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -71,6 +71,7 @@ export interface TerminalOptions {
   Terminal: any;
   FitAddon?: any;
   WebglAddon?: any;
+  SerializeAddon?: any;
   theme?: TerminalTheme;
   fontSize?: number;
   fontFamily?: string;


### PR DESCRIPTION
This PR adds `@xterm/addon-serialize` as a peer dependency and integrates it into the `NodepodTerminal` class.

**why**

Previously, calling `NodepodTerminal.detach()` disposed the xterm instance, which meant the visible terminal buffer was lost. Reattaching created a fresh xterm with no prior output.

**what this enables**

The terminal buffer is now snapshotted before disposal and restored on the next attach. This allows terminal state to persist across pane moves, portals, layout rerenders, splits, and other UI changes—without affecting the underlying shell/process.