### PR TITLE
fix: clear terminal scrollback with shell "clear"

### DIFF
--- a/src/shell/commands/shell-env.ts
+++ b/src/shell/commands/shell-env.ts
@@ -119,7 +119,7 @@ const exitCmd: BuiltinFn = (args) => {
   return { stdout: "", stderr: "", exitCode: code };
 };
 
-const clear: BuiltinFn = () => ok("\x1b[2J\x1b[H");
+const clear: BuiltinFn = () => ok("\x1b[H\x1b[2J\x1b[3J");
 
 /* ------------------------------------------------------------------ */
 /*  test / [                                                           */


### PR DESCRIPTION
Just adds \x1b[3J to the clear command output so that it also clears lines not in the current viewport.