### PR TITLE
fix: transparent virtual-prefix url for preview iframes

### DIFF
--- a/examples/issue-44-react-router-basename/index.html
+++ b/examples/issue-44-react-router-basename/index.html
@@ -1,0 +1,285 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>nodepod - issue #44 followup - react router basename</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: monospace; background: #1a1a2e; color: #e0e0e0; padding: 20px; line-height: 1.5; }
+    h1 { font-size: 18px; margin-bottom: 4px; color: #fff; }
+    p { font-size: 13px; color: #888; margin-bottom: 12px; max-width: 900px; }
+    a { color: #8ac4e6; }
+    code { background: #0d0d1a; padding: 2px 6px; border-radius: 3px; color: #a8e6a3; font-size: 12px; }
+    .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+    .pane {
+      background: #0d0d1a; border: 1px solid #333; border-radius: 6px;
+      padding: 12px; display: flex; flex-direction: column; min-height: 560px;
+    }
+    .pane h2 { font-size: 13px; margin-bottom: 8px; color: #8ac4e6; }
+    #output {
+      flex: 1; white-space: pre-wrap; font-size: 12px; line-height: 1.55;
+      overflow-y: auto; max-height: 540px;
+    }
+    #frame { flex: 1; border: 1px solid #333; border-radius: 4px; background: #fff; min-height: 400px; }
+    #status {
+      font-size: 12px; padding: 6px 10px; border-radius: 3px;
+      background: #181830; color: #aaa; border: 1px solid #222; margin-bottom: 8px;
+    }
+    .stdout { color: #a8e6a3; }
+    .stderr { color: #e68a8a; }
+    .info { color: #8ac4e6; }
+    .dim { color: #666; }
+    .pass { color: #a8e6a3; font-weight: bold; }
+    .fail { color: #e68a8a; font-weight: bold; }
+    .warn { color: #e6c38a; }
+    .title { color: #c38ae6; font-weight: bold; }
+    .controls { display: flex; gap: 8px; margin-bottom: 12px; align-items: center; flex-wrap: wrap; }
+    button {
+      background: #2a2a4a; color: #e0e0e0; border: 1px solid #444;
+      padding: 6px 12px; border-radius: 4px; font-family: monospace; cursor: pointer;
+    }
+    button:hover { background: #3a3a5a; }
+    button:disabled { opacity: 0.5; cursor: not-allowed; }
+  </style>
+</head>
+<body>
+  <h1>nodepod - issue <a href="https://github.com/ScelarOrg/Nodepod/issues/44">#44</a> followup - react router basename</h1>
+  <p>
+    repro of the followup report: a vite + react app using
+    react-router-dom BrowserRouter mounted inside a nodepod iframe never
+    matches any app routes. the iframe's location.pathname is
+    <code>/__virtual__/podXXXX/5173/</code>, which doesn't line up with
+    routes declared as <code>/</code>, <code>/about</code> etc. the user
+    gets the catch-all (NoMatch) branch and the iframe devtools logs
+    <code>No routes matched location "/__virtual__/pod.../5173/"</code>.
+  </p>
+
+  <div class="controls">
+    <button id="run">boot + install + dev</button>
+    <button id="clear">clear log</button>
+  </div>
+
+  <div class="layout">
+    <div class="pane">
+      <h2>log</h2>
+      <div id="output"></div>
+    </div>
+    <div class="pane">
+      <h2>preview iframe</h2>
+      <div id="status">idle</div>
+      <iframe id="frame" sandbox="allow-scripts allow-same-origin allow-forms allow-popups"></iframe>
+    </div>
+  </div>
+
+  <script type="module">
+    import { Nodepod } from "/dist/index.mjs";
+
+    // project files as JS template literals. the escape <\/ inside any
+    // script-tag strings gets unescaped when the template literal runs
+    const FILES = {
+      '/app/package.json': `{
+  "name": "router-repro",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^7.0.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^5.0.0",
+    "vite": "8.0.10"
+  }
+}
+`,
+
+      '/app/vite.config.js': `import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: { host: '0.0.0.0', port: 5173, strictPort: true },
+});
+`,
+
+      '/app/index.html': `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>router repro</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"><\/script>
+  </body>
+</html>
+`,
+
+      '/app/src/main.jsx': `import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App.jsx';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);
+`,
+
+      '/app/src/App.jsx': `import { Routes, Route, Link, useLocation } from 'react-router-dom';
+
+function DebugBar() {
+  const loc = useLocation();
+  return (
+    <div style={{ background: '#eef', padding: 8, fontFamily: 'monospace', fontSize: 12 }}>
+      <div>router location.pathname = <b>{loc.pathname}</b></div>
+      <div>window.location.pathname = <b>{window.location.pathname}</b></div>
+    </div>
+  );
+}
+
+function Home() {
+  return (
+    <div style={{ padding: 24 }}>
+      <h1>home</h1>
+      <p>if you see this, react-router matched the / route correctly.</p>
+      <Link to="/about">go to /about</Link>
+    </div>
+  );
+}
+
+function About() {
+  return (
+    <div style={{ padding: 24 }}>
+      <h1>about</h1>
+      <Link to="/">back home</Link>
+    </div>
+  );
+}
+
+function NoMatch() {
+  return (
+    <div style={{ padding: 24, background: '#fee', color: '#900' }}>
+      <h1>no route matched</h1>
+      <p>
+        BrowserRouter saw pathname <code>{window.location.pathname}</code> and
+        none of the app routes match. this is the bug.
+      </p>
+    </div>
+  );
+}
+
+export default function App() {
+  return (
+    <>
+      <DebugBar />
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/about" element={<About />} />
+        <Route path="*" element={<NoMatch />} />
+      </Routes>
+    </>
+  );
+}
+`,
+    };
+
+    const out = document.getElementById('output');
+    const frame = document.getElementById('frame');
+    const statusEl = document.getElementById('status');
+    const runBtn = document.getElementById('run');
+    const clearBtn = document.getElementById('clear');
+
+    function log(t, cls = 'stdout') {
+      const span = document.createElement('span');
+      span.className = cls;
+      span.textContent = t + '\n';
+      out.appendChild(span);
+      out.scrollTop = out.scrollHeight;
+    }
+    function setStatus(t, cls = '') { statusEl.textContent = t; statusEl.className = cls; }
+    clearBtn.addEventListener('click', () => { out.textContent = ''; });
+
+    runBtn.addEventListener('click', async () => {
+      runBtn.disabled = true;
+      frame.removeAttribute('src');
+      try {
+        log('booting nodepod (workdir=/app) ...', 'info');
+        setStatus('booting ...', 'warn');
+
+        let serverUrl = null;
+        const ready = new Promise((resolve) => {
+          window.__onReady = (url) => { serverUrl = url; resolve(url); };
+        });
+
+        const pod = await Nodepod.boot({
+          workdir: '/app',
+          watermark: false,
+          onServerReady: (port, url) => {
+            log(`[onServerReady] port=${port} url=${url}`, 'info');
+            window.__onReady(url);
+          },
+        });
+        log('booted.\n', 'info');
+
+        log('writing project files ...', 'info');
+        await Promise.all(
+          Object.entries(FILES).map(([p, c]) => pod.fs.writeFile(p, c))
+        );
+        log('done.\n', 'info');
+
+        log('--- npm install ---', 'title');
+        const install = await pod.spawn('npm', ['install']);
+        install.on('output', (t) => log(t.trimEnd(), 'stdout'));
+        install.on('error',  (t) => log(t.trimEnd(), 'stderr'));
+        const installRes = await install.completion;
+        if (installRes.exitCode !== 0) {
+          log(`install failed (exit=${installRes.exitCode})`, 'fail');
+          setStatus('install failed', 'fail');
+          return;
+        }
+        log('install done.\n', 'pass');
+
+        log('--- npm run dev ---', 'title');
+        setStatus('starting dev ...', 'warn');
+        const dev = await pod.spawn('npm', ['run', 'dev']);
+        dev.on('output', (t) => log(t.trimEnd(), 'stdout'));
+        dev.on('error',  (t) => log(t.trimEnd(), 'stderr'));
+
+        const url = await Promise.race([
+          ready,
+          new Promise((r) => setTimeout(() => r(null), 60000)),
+        ]);
+        if (!url) {
+          log('timeout waiting for dev server', 'fail');
+          setStatus('timeout', 'fail');
+          dev.kill();
+          return;
+        }
+
+        log(`\npointing iframe at ${url}`, 'info');
+        log(`BrowserRouter will see pathname = ${new URL(url).pathname}`, 'warn');
+        log(`expected: the red "no route matched" box renders`, 'warn');
+        setStatus('check the iframe', 'warn');
+        frame.src = url;
+      } catch (e) {
+        log(`\nuncaught: ${e?.stack || e}`, 'fail');
+        setStatus('uncaught', 'fail');
+      } finally {
+        runBtn.disabled = false;
+      }
+    });
+  </script>
+</body>
+</html>

--- a/static/__sw__.js
+++ b/static/__sw__.js
@@ -37,6 +37,11 @@ const instancePorts = new Map();
 // clientId -> { instanceId, serverPort } for preview iframes
 const previewClients = new Map();
 
+// stripped path -> pod. iframes claim their path so a reload that lands on
+// the stripped url (no prefix, new clientId) can still be routed. bounded.
+const pathToPodMap = new Map();
+const PATH_MAP_MAX = 512;
+
 // per-instance script injected into preview iframe HTML
 const previewScripts = new Map();
 
@@ -270,6 +275,23 @@ self.addEventListener("message", (event) => {
     return;
   }
 
+  // iframe claims its stripped path. we look up the pod from the sender's
+  // clientId so a page can't claim for a pod it isn't already tied to.
+  if (data.type === "nodepod-path-claim" && typeof data.path === "string") {
+    const clientId = event.source && event.source.id;
+    const pod = clientId ? previewClients.get(clientId) : null;
+    if (pod) {
+      if (pathToPodMap.size >= PATH_MAP_MAX) {
+        const oldest = pathToPodMap.keys().next().value;
+        if (oldest !== undefined) pathToPodMap.delete(oldest);
+      }
+      // re-insert to bump recency
+      pathToPodMap.delete(data.path);
+      pathToPodMap.set(data.path, pod);
+    }
+    return;
+  }
+
   // everything else requires a token from some live tab
   if (!isValidToken(data.token)) return;
 
@@ -451,6 +473,31 @@ self.addEventListener("fetch", (event) => {
       }
     } catch {
       // Invalid referer URL, ignore
+    }
+  }
+
+  // 5. fallback: path-claim map. catches iframe reloads where the URL was
+  //    stripped by the location patch, so clientId and referer are no help.
+  //    gated to iframe/frame navigations so outer-page top-level nav to a
+  //    path that happens to be claimed doesn't get misrouted to a pod.
+  {
+    const dest = event.request.destination;
+    const isIframeNav = event.request.mode === "navigate" && (dest === "iframe" || dest === "frame");
+    const host = url.hostname;
+    const sameOrigin = host === "localhost" || host === "127.0.0.1" || host === "0.0.0.0" || host === self.location.hostname;
+    if (isIframeNav && sameOrigin) {
+      const pathHit = pathToPodMap.get(url.pathname);
+      if (pathHit) {
+        const { instanceId, serverPort } = pathHit;
+        const path = url.pathname + url.search;
+        if (event.resultingClientId) {
+          previewClients.set(event.resultingClientId, { instanceId, serverPort });
+        }
+        event.respondWith(
+          proxyToVirtualServer(event.request, instanceId, serverPort, path, event.request),
+        );
+        return;
+      }
     }
   }
 
@@ -648,6 +695,105 @@ function getWsShimScript(instanceId) {
 </script>`;
 }
 
+// ── Virtual-prefix URL patch ──
+//
+// iframes live at /__virtual__/{id}/{port}/ but client-side routers read
+// location.pathname and want the app's real path. Location is
+// [LegacyUnforgeable] so we can't override its getters. instead we strip
+// the prefix from the real URL via history.replaceState before any user
+// script runs. SW routes later requests via clientId, with the path-claim
+// map as a fallback for force-reloads.
+const LOCATION_PATCH_SCRIPT = `<script>
+(function() {
+  if (window.__nodepodLocPatch) return;
+  window.__nodepodLocPatch = true;
+
+  // /__virtual__/{id}/{port} (|\\d+ branch is the legacy id-less form)
+  var PREFIX_RE = /^\\/__(?:preview|virtual)__\\/(?:[A-Za-z0-9_-]*[A-Za-z_-][A-Za-z0-9_-]*\\/\\d+|\\d+)/;
+
+  var m = location.pathname.match(PREFIX_RE);
+  if (!m) return;
+  var PREFIX = m[0];
+
+  function strip(u) {
+    if (typeof u !== 'string') return u;
+    if (u === PREFIX) return '/';
+    if (u.indexOf(PREFIX + '/') === 0) return u.slice(PREFIX.length);
+    if (u.indexOf(PREFIX + '?') === 0) return '/' + u.slice(PREFIX.length);
+    if (u.indexOf(PREFIX + '#') === 0) return '/' + u.slice(PREFIX.length);
+    return u;
+  }
+
+  // let the SW know our path so a force-reload without the prefix still routes
+  function claimPath() {
+    try {
+      var sw = navigator.serviceWorker && navigator.serviceWorker.controller;
+      if (sw) sw.postMessage({ type: 'nodepod-path-claim', path: location.pathname });
+    } catch (e) {}
+  }
+
+  // swap the visible URL to the stripped form. same document, just history.
+  try {
+    var newPath = strip(location.pathname);
+    if (newPath !== location.pathname) {
+      history.replaceState(history.state, '', newPath + location.search + location.hash);
+    }
+  } catch (e) {
+    console.warn('[nodepod] initial URL strip failed:', e);
+  }
+  claimPath();
+
+  // strip any prefix user code passes, re-claim on every nav so the SW's
+  // fallback map stays current
+  var origPush = history.pushState;
+  var origRepl = history.replaceState;
+  history.pushState = function(state, title, url) {
+    if (typeof url === 'string') url = strip(url);
+    var r = origPush.call(this, state, title, url);
+    claimPath();
+    return r;
+  };
+  history.replaceState = function(state, title, url) {
+    if (typeof url === 'string') url = strip(url);
+    var r = origRepl.call(this, state, title, url);
+    claimPath();
+    return r;
+  };
+  window.addEventListener('popstate', claimPath);
+
+  // plain <a href="/..."> clicks would full-navigate and lose our clientId.
+  // turn them into pushState. bubble phase so framework Link handlers win.
+  document.addEventListener('click', function(ev) {
+    if (ev.defaultPrevented || ev.button !== 0) return;
+    if (ev.metaKey || ev.ctrlKey || ev.altKey || ev.shiftKey) return;
+    var el = ev.target;
+    while (el && el.nodeName !== 'A') el = el.parentNode;
+    if (!el || !el.getAttribute) return;
+    if (el.target && el.target !== '' && el.target !== '_self') return;
+    if (el.hasAttribute('download')) return;
+    var raw = el.getAttribute('href');
+    if (!raw || raw.charAt(0) !== '/' || raw.charAt(1) === '/') return;
+    ev.preventDefault();
+    var target = strip(raw);
+    if (target !== location.pathname + location.search + location.hash) {
+      history.pushState({}, '', target);
+      dispatchEvent(new PopStateEvent('popstate', { state: history.state }));
+    }
+  });
+
+  // <form action="/..."> posts to origin. strip any prefix before submit,
+  // SW handles the rest via clientId.
+  document.addEventListener('submit', function(ev) {
+    var form = ev.target;
+    if (!form || form.nodeName !== 'FORM') return;
+    var a = form.getAttribute('action');
+    if (!a) return;
+    var stripped = strip(a);
+    if (stripped !== a) form.setAttribute('action', stripped);
+  }, true);
+})();
+</script>`;
+
 // Small "nodepod" badge in the bottom-right corner of preview iframes.
 const WATERMARK_SCRIPT = `<script>
 (function() {
@@ -821,7 +967,8 @@ async function proxyToVirtualServer(request, instanceId, serverPort, path, origi
     let finalBody = responseBody;
     const ct = respHeaders["content-type"] || respHeaders["Content-Type"] || "";
     if (ct.includes("text/html") && responseBody) {
-      let injection = getWsShimScript(instanceId);
+      // location patch runs first so user scripts see the stripped URL
+      let injection = LOCATION_PATCH_SCRIPT + getWsShimScript(instanceId);
       const previewScript = previewScripts.get(instanceId);
       if (previewScript) {
         injection += `<script>${previewScript}<` + `/script>`;


### PR DESCRIPTION
client-side routers (react-router, vue-router, sveltekit, etc) read location.pathname to pick a route. iframes served by the SW live at /__virtual__/{id}/{port}/ so every router saw that prefix and matched nothing. the reporter was working around it by injecting a basename into every user app.

cannt patch Location.prototype, its accessors are LegacyUnforgeable per the HTML spec, so Object.defineProperty silently skips them (and the descriptor literally isnt there in firefox) instead the SW injects a small script into every iframe html response that runs before any user code. it strips the prefix from the real URL via history.replaceState, which the browser actually respects. after that location.pathname reads as the app's real path and every framework just works.

for navigations the patch also strips any prefix that leaks into pushState/replaceState, and hijacks plain ```<a href="/...">``` clicks into pushState so a full navigation doesnt leave us with a fresh clientId the SW can't route. bubble phase so framework Link handlers get first crack at preventDefault.

force reload of an iframe lands on the stripped url with a new clientId and no prefix in referer, so the existing fallbacks can't route. added a pathToPodMap in the SW that each iframe keeps up to date via postMessage on load and on every pushState. the fetch handler gets a new fallback 5 that looks up the path there, but only for iframe/frame navigations. gated by request.destination so top-level navigation in the outer app cant accidentally get routed into a pod.

map is bounded to 512 entries with oldest-out eviction.

added examples/issue-44-react-router-basename as a repro, all 573 tests still pass.