### PR TITLE
feat(git-native): 'native' git impl

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,47 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  unit:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install
+      - run: pnpm run build:lib
+      - run: pnpm test
+
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install
+      - run: pnpm run build:lib
+      - run: npx playwright install --with-deps chromium
+      - run: pnpm test:e2e

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,18 +13,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: pnpm
+          cache: npm
 
-      - run: pnpm install
-      - run: pnpm run build:lib
-      - run: pnpm test
+      - run: npm ci
+      - run: npm run build:lib
+      - run: npm test
 
   e2e:
     name: E2E Tests
@@ -32,16 +28,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: pnpm
+          cache: npm
 
-      - run: pnpm install
-      - run: pnpm run build:lib
+      - run: npm ci
+      - run: npm run build:lib
       - run: npx playwright install --with-deps chromium
-      - run: pnpm test:e2e
+      - run: npm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,8 @@ pnpm-debug.log*
 # Test coverage
 coverage/
 
+# Test results
+test-results/
+
 # Local research / planning notes (Claude Code scratch)
 memory/

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,30 +14,42 @@
         "brotli": "^1.3.3",
         "brotli-wasm": "^3.0.1",
         "comlink": "^4.4.2",
+        "isomorphic-git": "^1.37.5",
         "pako": "^2.1.0",
         "resolve.exports": "^2.0.3",
+        "sha.js": "^2.4.12",
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@playwright/test": "^1.53.1",
         "@types/node": "^25.0.10",
         "@types/pako": "^2.0.4",
+        "@vitest/browser": "^4.1.5",
         "esbuild": "^0.27.2",
+        "playwright": "^1.53.1",
+        "tsx": "^4.21.0",
         "typescript": "^5.9.3",
-        "vite": "^5.4.0",
+        "vite": "^6.0.0",
         "vite-plugin-top-level-await": "^1.6.0",
         "vite-plugin-wasm": "^3.5.0",
-        "vitest": "^4.0.18"
+        "vitest": "^4.1.5"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@xterm/addon-fit": "^0.11.0",
+        "@xterm/addon-serialize": "^0.14.0",
         "@xterm/addon-webgl": "^0.19.0",
-        "@xterm/xterm": "^6.0.0"
+        "@xterm/xterm": "^6.0.0",
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@xterm/addon-fit": {
+          "optional": true
+        },
+        "@xterm/addon-serialize": {
           "optional": true
         },
         "@xterm/addon-webgl": {
@@ -45,8 +57,21 @@
         },
         "@xterm/xterm": {
           "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
         }
       }
+    },
+    "node_modules/@blazediff/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@blazediff/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",
@@ -493,6 +518,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/plugin-virtual": {
       "version": "3.0.2",
       "dev": true,
@@ -857,6 +905,8 @@
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1085,6 +1135,8 @@
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1094,6 +1146,8 @@
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1116,39 +1170,95 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@vitest/expect": {
-      "version": "4.0.18",
+    "node_modules/@vitest/browser": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.5.tgz",
+      "integrity": "sha512-iCDGI8c4yg+xmjUg2VsygdAUSIIB4x5Rht/P68OXy1hPELKXHDkzh87lkuTcdYmemRChDkEpB426MmDjzC0ziA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
+        "@blazediff/core": "1.9.1",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pngjs": "^7.0.0",
+        "sirv": "^3.0.2",
+        "tinyrainbow": "^3.1.0",
+        "ws": "^8.19.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.1.5"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "chai": "^6.2.1",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/pretty-format": {
-      "version": "4.0.18",
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.18",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.18",
+        "@vitest/utils": "4.1.5",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1156,11 +1266,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.18",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1169,7 +1282,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.0.18",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1177,15 +1292,30 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.18",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
       }
     },
     "node_modules/acorn": {
@@ -1208,10 +1338,33 @@
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/async-lock": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
+      "license": "MIT"
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/base64-js": {
@@ -1246,22 +1399,204 @@
         "node": ">=v18.0.0"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
+    "node_modules/clean-git-ref": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
+      "integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/comlink": {
       "version": "4.4.2",
       "license": "Apache-2.0"
     },
-    "node_modules/es-module-lexer": {
-      "version": "1.7.0",
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/diff3": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
+      "integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
+      "license": "MIT"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -1305,10 +1640,30 @@
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
       }
     },
     "node_modules/expect-type": {
@@ -1321,6 +1676,8 @@
     },
     "node_modules/fdir": {
       "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1333,6 +1690,21 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/fsevents": {
@@ -1350,12 +1722,282 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
+    },
+    "node_modules/isomorphic-git": {
+      "version": "1.37.5",
+      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.37.5.tgz",
+      "integrity": "sha512-wek54c5uFvd3WsxewLWt6h0GXKWQh0P8rRXns9bN1rHNjcgCb3+0lmyAsP594NeTtQFeCJQVS9b0kjbkD1l5qg==",
+      "license": "MIT",
+      "dependencies": {
+        "async-lock": "^1.4.1",
+        "clean-git-ref": "^2.0.1",
+        "crc-32": "^1.2.0",
+        "diff3": "0.0.3",
+        "ignore": "^5.1.4",
+        "minimisted": "^2.0.0",
+        "pako": "^1.0.10",
+        "pify": "^4.0.1",
+        "readable-stream": "^4.0.0",
+        "sha.js": "^2.4.12",
+        "simple-get": "^4.0.1"
+      },
+      "bin": {
+        "isogit": "cli.cjs"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/isomorphic-git/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minimisted": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
+      "integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/nanoid": {
@@ -1384,12 +2026,23 @@
       ],
       "license": "MIT"
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/pako": {
       "version": "2.1.0",
       "license": "(MIT AND Zlib)"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1399,7 +2052,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1408,6 +2063,81 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -1435,6 +2165,41 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/resolve.exports": {
@@ -1488,10 +2253,127 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -1507,9 +2389,20 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -1525,12 +2418,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -1540,11 +2435,72 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.0.3",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/typescript": {
@@ -1577,20 +2533,25 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.21",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "esbuild": "^0.21.3",
-        "postcss": "^8.4.43",
-        "rollup": "^4.20.0"
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -1599,625 +2560,14 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || >=20.0.0",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
         "less": "*",
         "lightningcss": "^1.21.0",
         "sass": "*",
         "sass-embedded": "*",
         "stylus": "*",
         "sugarss": "*",
-        "terser": "^5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite-plugin-top-level-await": {
-      "version": "1.6.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/plugin-virtual": "^3.0.2",
-        "@swc/core": "^1.12.14",
-        "@swc/wasm": "^1.12.14",
-        "uuid": "10.0.0"
-      },
-      "peerDependencies": {
-        "vite": ">=2.8"
-      }
-    },
-    "node_modules/vite-plugin-wasm": {
-      "version": "3.5.0",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "vite": "^2 || ^3 || ^4 || ^5 || ^6 || ^7"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/esbuild": {
-      "version": "0.21.5",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.5",
-        "@esbuild/android-arm": "0.21.5",
-        "@esbuild/android-arm64": "0.21.5",
-        "@esbuild/android-x64": "0.21.5",
-        "@esbuild/darwin-arm64": "0.21.5",
-        "@esbuild/darwin-x64": "0.21.5",
-        "@esbuild/freebsd-arm64": "0.21.5",
-        "@esbuild/freebsd-x64": "0.21.5",
-        "@esbuild/linux-arm": "0.21.5",
-        "@esbuild/linux-arm64": "0.21.5",
-        "@esbuild/linux-ia32": "0.21.5",
-        "@esbuild/linux-loong64": "0.21.5",
-        "@esbuild/linux-mips64el": "0.21.5",
-        "@esbuild/linux-ppc64": "0.21.5",
-        "@esbuild/linux-riscv64": "0.21.5",
-        "@esbuild/linux-s390x": "0.21.5",
-        "@esbuild/linux-x64": "0.21.5",
-        "@esbuild/netbsd-x64": "0.21.5",
-        "@esbuild/openbsd-x64": "0.21.5",
-        "@esbuild/sunos-x64": "0.21.5",
-        "@esbuild/win32-arm64": "0.21.5",
-        "@esbuild/win32-ia32": "0.21.5",
-        "@esbuild/win32-x64": "0.21.5"
-      }
-    },
-    "node_modules/vitest": {
-      "version": "4.0.18",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/expect": "4.0.18",
-        "@vitest/mocker": "4.0.18",
-        "@vitest/pretty-format": "4.0.18",
-        "@vitest/runner": "4.0.18",
-        "@vitest/snapshot": "4.0.18",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "es-module-lexer": "^1.7.0",
-        "expect-type": "^1.2.2",
-        "magic-string": "^0.30.21",
-        "obug": "^2.1.1",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
-        "std-env": "^3.10.0",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@opentelemetry/api": "^1.9.0",
-        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.18",
-        "@vitest/browser-preview": "4.0.18",
-        "@vitest/browser-webdriverio": "4.0.18",
-        "@vitest/ui": "4.0.18",
-        "happy-dom": "*",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser-playwright": {
-          "optional": true
-        },
-        "@vitest/browser-preview": {
-          "optional": true
-        },
-        "@vitest/browser-webdriverio": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vitest/node_modules/@vitest/mocker": {
-      "version": "4.0.18",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "4.0.18",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vitest/node_modules/vite": {
-      "version": "7.3.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
         "terser": "^5.16.0",
         "tsx": "^4.8.1",
         "yaml": "^2.4.2"
@@ -2258,6 +2608,624 @@
         }
       }
     },
+    "node_modules/vite-plugin-top-level-await": {
+      "version": "1.6.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/plugin-virtual": "^3.0.2",
+        "@swc/core": "^1.12.14",
+        "@swc/wasm": "^1.12.14",
+        "uuid": "10.0.0"
+      },
+      "peerDependencies": {
+        "vite": ">=2.8"
+      }
+    },
+    "node_modules/vite-plugin-wasm": {
+      "version": "3.5.0",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "vite": "^2 || ^3 || ^4 || ^5 || ^6 || ^7"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "dev": true,
@@ -2271,6 +3239,34 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "build:publish": "npm run build:lib && npm run build:types",
     "type-check": "tsc --noEmit",
     "test": "vitest run",
+    "test:e2e": "npx playwright test",
     "test:watch": "vitest",
     "bench": "vitest bench",
     "bench:run": "vitest bench --run",
@@ -95,17 +96,19 @@
     "brotli": "^1.3.3",
     "brotli-wasm": "^3.0.1",
     "comlink": "^4.4.2",
+    "isomorphic-git": "^1.37.5",
     "pako": "^2.1.0",
     "resolve.exports": "^2.0.3",
+    "sha.js": "^2.4.12",
     "zod": "^4.3.6"
   },
   "peerDependencies": {
-    "@xterm/xterm": "^6.0.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/addon-serialize": "^0.14.0",
-    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
-    "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+    "@xterm/xterm": "^6.0.0",
+    "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "peerDependenciesMeta": {
     "@xterm/xterm": {
@@ -131,10 +134,14 @@
     "@types/node": "^25.0.10",
     "@types/pako": "^2.0.4",
     "esbuild": "^0.27.2",
+    "tsx": "^4.21.0",
     "typescript": "^5.9.3",
-    "vite": "^5.4.0",
+    "@playwright/test": "^1.53.1",
+    "@vitest/browser": "^4.1.5",
+    "playwright": "^1.53.1",
+    "vite": "^6.0.0",
     "vite-plugin-top-level-await": "^1.6.0",
     "vite-plugin-wasm": "^3.5.0",
-    "vitest": "^4.0.18"
+    "vitest": "^4.1.5"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './src/__tests__/e2e',
+  timeout: 60000,
+  projects: [
+    {
+      name: 'git-clone',
+      testDir: './src/__tests__/e2e/git-clone',
+      testMatch: '*.test.ts',
+      use: { baseURL: 'http://localhost:4567' },
+    },
+    {
+      name: 'git-clone-api',
+      testDir: './src/__tests__/e2e/git-clone-api',
+      testMatch: '*.test.ts',
+      use: { baseURL: 'http://localhost:4568' },
+    },
+  ],
+  webServer: [
+    {
+      command: 'npx vite --config src/__tests__/e2e/git-clone/vite.config.ts',
+      port: 4567,
+      reuseExistingServer: true,
+      timeout: 30000,
+    },
+    {
+      command: 'npx vite --config src/__tests__/e2e/git-clone-api/vite.config.ts',
+      port: 4568,
+      reuseExistingServer: true,
+      timeout: 30000,
+    },
+  ],
+});

--- a/src/__tests__/e2e/git-clone-api/git-clone-api.test.ts
+++ b/src/__tests__/e2e/git-clone-api/git-clone-api.test.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+import { startMockGithub } from './mock-github';
+import { boot, gitClone, listFiles, readFile } from '../utils/page-helpers';
+import type { Server } from 'node:http';
+
+let mockServer: Server;
+
+test.beforeAll(async () => {
+  mockServer = await startMockGithub(4569);
+});
+
+test.afterAll(async () => {
+  mockServer?.close();
+});
+
+test.describe('git clone API mode', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:4568');
+    expect(await boot(page)).toBe(true);
+  });
+
+  test('clones mock repo and checks out files', async ({ page }) => {
+    const result = await gitClone(page, 'https://github.com/test-org/test-repo');
+    expect(result.exitCode).toBe(0);
+
+    const files = await listFiles(page, '/workspace/test-repo');
+    expect(files).toContain('package.json');
+    expect(files).toContain('README.md');
+
+    const pkgContent = await readFile(page, '/workspace/test-repo/package.json');
+    expect(pkgContent).toBeTruthy();
+    const pkg = JSON.parse(pkgContent);
+    expect(pkg.name).toBe('test-repo');
+  });
+
+  test('clones mock repo with subdirectories', async ({ page }) => {
+    const result = await gitClone(page, 'https://github.com/test-org/test-repo');
+    expect(result.exitCode).toBe(0);
+
+    const content = await readFile(page, '/workspace/test-repo/src/index.ts');
+    expect(content).toBeTruthy();
+    expect(content).toContain('hello');
+  });
+
+  test('README.md has expected content', async ({ page }) => {
+    await gitClone(page, 'https://github.com/test-org/test-repo');
+    const readme = await readFile(page, '/workspace/test-repo/README.md');
+    expect(readme).toContain('mock repository');
+  });
+
+  test('clone non-existent repo returns error', async ({ page }) => {
+    const result = await gitClone(page, 'https://github.com/test-org/nonexistent-repo');
+    expect(result.exitCode).not.toBe(0);
+  });
+});

--- a/src/__tests__/e2e/git-clone-api/index.html
+++ b/src/__tests__/e2e/git-clone-api/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head><title>nodepod git-clone-api e2e</title></head>
+<body>
+<pre id="output"></pre>
+<script type="module" src="./main.ts"></script>
+</body>
+</html>

--- a/src/__tests__/e2e/git-clone-api/main.ts
+++ b/src/__tests__/e2e/git-clone-api/main.ts
@@ -1,0 +1,19 @@
+import { Nodepod } from '@scelar/nodepod';
+import { createTestApi } from '../utils/test-api';
+
+const output = document.getElementById('output')!;
+const log = (msg: string) => { output.textContent += msg + '\n'; console.log(msg); };
+
+(window as any).__nodepodTest = createTestApi(
+  () => Nodepod.boot({
+    workdir: '/workspace',
+    git: 'api',
+    gitApiBase: 'http://localhost:4569/api',
+    gitRawBase: 'http://localhost:4569/raw',
+    serviceWorker: false,
+    watermark: false,
+  }),
+  log,
+);
+
+log('[test] fixture loaded (API mode)');

--- a/src/__tests__/e2e/git-clone-api/mock-github.ts
+++ b/src/__tests__/e2e/git-clone-api/mock-github.ts
@@ -1,0 +1,72 @@
+/**
+ * Mock GitHub API server for testing git clone in API mode.
+ * Serves fake repo metadata, tree, and file contents.
+ */
+import http from 'node:http';
+
+const MOCK_OWNER = 'test-org';
+const MOCK_REPO = 'test-repo';
+
+const files: Record<string, string> = {
+  'package.json': JSON.stringify({ name: 'test-repo', version: '1.0.0', private: true }, null, 2),
+  'README.md': '# Test Repo\n\nThis is a mock repository for testing git clone API mode.',
+  'src/index.ts': 'export const hello = "world";\n',
+};
+
+function handleRequest(req: http.IncomingMessage, res: http.ServerResponse) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Headers', '*');
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  const url = req.url || '';
+
+  // GET /api/repos/:owner/:repo
+  if (url === `/api/repos/${MOCK_OWNER}/${MOCK_REPO}`) {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      default_branch: 'main',
+      name: MOCK_REPO,
+      full_name: `${MOCK_OWNER}/${MOCK_REPO}`,
+    }));
+    return;
+  }
+
+  // GET /api/repos/:owner/:repo/git/trees/main?recursive=1
+  if (url.startsWith(`/api/repos/${MOCK_OWNER}/${MOCK_REPO}/git/trees/`)) {
+    const tree = Object.keys(files).map(path => ({
+      path,
+      type: 'blob',
+      sha: 'abc123',
+    }));
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ tree }));
+    return;
+  }
+
+  // GET /raw/:owner/:repo/:branch/:path — raw file content
+  const rawMatch = url.match(/^\/raw\/[^/]+\/[^/]+\/[^/]+\/(.+)$/);
+  if (rawMatch) {
+    const filePath = rawMatch[1];
+    if (files[filePath]) {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end(files[filePath]);
+      return;
+    }
+  }
+
+  // 404
+  res.writeHead(404, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ message: 'Not Found' }));
+}
+
+export function startMockGithub(port: number): Promise<http.Server> {
+  return new Promise((resolve) => {
+    const server = http.createServer(handleRequest);
+    server.listen(port, () => resolve(server));
+  });
+}

--- a/src/__tests__/e2e/git-clone-api/vite.config.ts
+++ b/src/__tests__/e2e/git-clone-api/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+import nodepod from '@scelar/nodepod/vite';
+
+export default defineConfig({
+  root: __dirname,
+  plugins: [nodepod()], // API mode — no git: 'native'
+  server: {
+    port: 4568,
+  },
+});

--- a/src/__tests__/e2e/git-clone/git-clone.test.ts
+++ b/src/__tests__/e2e/git-clone/git-clone.test.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+import { boot, gitClone, listFiles, readFile, fileExists } from '../utils/page-helpers';
+
+test.describe('git clone e2e', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:4567');
+    expect(await boot(page)).toBe(true);
+  });
+
+  test('clones ScelarOrg/Nodepod and checks out files', async ({ page }) => {
+    const result = await gitClone(page, 'https://github.com/ScelarOrg/Nodepod');
+    expect(result.exitCode).toBe(0);
+
+    const files = await listFiles(page, '/workspace/Nodepod');
+    expect(files).toContain('package.json');
+    expect(files).toContain('README.md');
+
+    const pkgContent = await readFile(page, '/workspace/Nodepod/package.json');
+    expect(pkgContent).toBeTruthy();
+    const pkg = JSON.parse(pkgContent);
+    expect(pkg.name).toBe('@scelar/nodepod');
+  });
+
+  test('README.md contains nodepod description', async ({ page }) => {
+    await gitClone(page, 'https://github.com/ScelarOrg/Nodepod');
+    const readme = await readFile(page, '/workspace/Nodepod/README.md');
+    expect(readme).toBeTruthy();
+    expect(readme.toLowerCase()).toContain('nodepod');
+  });
+
+  test('.git directory is created', async ({ page }) => {
+    await gitClone(page, 'https://github.com/ScelarOrg/Nodepod');
+    expect(await fileExists(page, '/workspace/Nodepod/.git')).toBe(true);
+    expect(await fileExists(page, '/workspace/Nodepod/.git/HEAD')).toBe(true);
+  });
+
+  test('clone non-existent repo returns error', async ({ page }) => {
+    const result = await gitClone(page, 'https://github.com/xyd-js/this-repo-does-not-exist-12345');
+    expect(result.exitCode).not.toBe(0);
+  });
+});

--- a/src/__tests__/e2e/git-clone/index.html
+++ b/src/__tests__/e2e/git-clone/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head><title>nodepod git e2e</title></head>
+<body>
+<pre id="output"></pre>
+<script type="module" src="./main.ts"></script>
+</body>
+</html>

--- a/src/__tests__/e2e/git-clone/main.ts
+++ b/src/__tests__/e2e/git-clone/main.ts
@@ -1,0 +1,18 @@
+import { Nodepod } from '@scelar/nodepod';
+import { createTestApi } from '../utils/test-api';
+
+const output = document.getElementById('output')!;
+const log = (msg: string) => { output.textContent += msg + '\n'; console.log(msg); };
+
+(window as any).__nodepodTest = createTestApi(
+  () => Nodepod.boot({
+    workdir: '/workspace',
+    git: 'native',
+    gitCorsProxy: `${window.location.origin}/__nodepod_git_proxy__`,
+    serviceWorker: false,
+    watermark: false,
+  }),
+  log,
+);
+
+log('[test] fixture loaded (native mode)');

--- a/src/__tests__/e2e/git-clone/vite.config.ts
+++ b/src/__tests__/e2e/git-clone/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+import nodepod from '@scelar/nodepod/vite';
+
+export default defineConfig({
+  root: __dirname,
+  plugins: [nodepod({ git: 'native' })],
+  server: {
+    port: 4567
+  }
+});

--- a/src/__tests__/e2e/utils/page-helpers.ts
+++ b/src/__tests__/e2e/utils/page-helpers.ts
@@ -1,0 +1,21 @@
+import type { Page } from '@playwright/test';
+
+export async function boot(page: Page) {
+  return page.evaluate(() => (window as any).__nodepodTest.boot());
+}
+
+export async function gitClone(page: Page, url: string, dir?: string) {
+  return page.evaluate(([u, d]) => (window as any).__nodepodTest.gitClone(u, d), [url, dir] as const);
+}
+
+export async function listFiles(page: Page, dir: string) {
+  return page.evaluate((d) => (window as any).__nodepodTest.listFiles(d), dir);
+}
+
+export async function readFile(page: Page, path: string) {
+  return page.evaluate((p) => (window as any).__nodepodTest.readFile(p), path);
+}
+
+export async function fileExists(page: Page, path: string) {
+  return page.evaluate((p) => (window as any).__nodepodTest.fileExists(p), path);
+}

--- a/src/__tests__/e2e/utils/test-api.ts
+++ b/src/__tests__/e2e/utils/test-api.ts
@@ -1,0 +1,66 @@
+import type { Nodepod } from '@scelar/nodepod';
+
+type NodepodInstance = Awaited<ReturnType<typeof Nodepod.boot>>;
+
+export interface TestApi {
+  ready: boolean;
+  pod: NodepodInstance | null;
+  boot(): Promise<boolean>;
+  gitClone(url: string, dir?: string): Promise<{ exitCode: number; stdout: string; stderr: string }>;
+  listFiles(dir: string): Promise<string[]>;
+  readFile(path: string): Promise<string | null>;
+  fileExists(path: string): Promise<boolean>;
+}
+
+export function createTestApi(
+  bootFn: () => Promise<NodepodInstance>,
+  log: (msg: string) => void,
+): TestApi {
+  const api: TestApi = {
+    ready: false,
+    pod: null,
+
+    async boot() {
+      log('[test] Booting Nodepod...');
+      api.pod = await bootFn();
+      api.ready = true;
+      log('[test] Nodepod ready');
+      return true;
+    },
+
+    async gitClone(url: string, dir?: string) {
+      if (!api.pod) throw new Error('Nodepod not booted');
+
+      const targetDir = dir || '/workspace/' + (url.split('/').pop()?.replace('.git', '') || 'repo');
+      log(`[test] git clone ${url} → ${targetDir}`);
+
+      const proc = await api.pod.spawn('git', ['clone', url, targetDir]);
+
+      let stdout = '';
+      let stderr = '';
+      proc.on('output', (text: string) => { stdout += text; log('[stdout] ' + text); });
+      proc.on('error', (text: string) => { stderr += text; log('[stderr] ' + text); });
+
+      const result = await proc.completion;
+      log(`[test] clone exit code: ${result.exitCode}`);
+      return { exitCode: result.exitCode, stdout: result.stdout || stdout, stderr: result.stderr || stderr };
+    },
+
+    async listFiles(dir: string) {
+      if (!api.pod) throw new Error('Nodepod not booted');
+      try { return await api.pod.fs.readdir(dir) as string[]; } catch { return []; }
+    },
+
+    async readFile(path: string) {
+      if (!api.pod) throw new Error('Nodepod not booted');
+      try { return await api.pod.fs.readFile(path, 'utf8') as string; } catch { return null; }
+    },
+
+    async fileExists(path: string) {
+      if (!api.pod) throw new Error('Nodepod not booted');
+      try { await api.pod.fs.stat(path); return true; } catch { return false; }
+    },
+  };
+
+  return api;
+}

--- a/src/integrations/vite.ts
+++ b/src/integrations/vite.ts
@@ -15,6 +15,8 @@ import { swResponseHeaders, DEFAULT_SW_PATH } from "./shared/headers";
 export interface NodepodVitePluginOptions {
   /** Path to serve the SW from. Same origin as the page, must end in .js. Defaults to /__sw__.js. */
   path?: string;
+  /** Git mode. `'native'` uses real Git Smart HTTP protocol (CORS proxy auto-configured). Defaults to `'api'` (GitHub REST API). */
+  git?: 'api' | 'native';
 }
 
 export default function nodepod(
@@ -24,8 +26,48 @@ export default function nodepod(
   // Rollup asset names are relative to outDir, so drop the leading slash.
   const assetFileName = swPath.replace(/^\/+/, "");
 
+  const gitProxyPath = opts.git === "native" ? "/__nodepod_git_proxy__" : undefined;
+
   return {
     name: "nodepod",
+    config() {
+      if (!gitProxyPath) return;
+
+      // Resolve Nodepod's crypto polyfill for isomorphic-git.
+      // isomorphic-git does require('crypto').createHash which doesn't exist in browser.
+      let cryptoPath = "";
+      try {
+        const nodepodMain = require.resolve("@scelar/nodepod");
+        cryptoPath = nodepodMain.replace(/\/dist\/.*/, "/src/polyfills/crypto.ts");
+      } catch { /* isomorphic-git will fail with createHash error */ }
+
+      return {
+        resolve: {
+          alias: cryptoPath ? { crypto: cryptoPath } : {},
+        },
+        optimizeDeps: {
+          esbuildOptions: {
+            plugins: cryptoPath ? [{
+              name: "nodepod-crypto-shim",
+              setup(build: any) {
+                build.onResolve({ filter: /^crypto$/ }, () => ({
+                  path: cryptoPath,
+                }));
+              },
+            }] : [],
+          },
+        },
+        server: {
+          proxy: {
+            [gitProxyPath]: {
+              target: "https://github.com",
+              changeOrigin: true,
+              rewrite: (path: string) => path.replace(new RegExp(`^${gitProxyPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\/github\\.com`), ""),
+            },
+          },
+        },
+      };
+    },
     configureServer(server) {
       // Match on the path alone so the SDK's `?v=${Date.now()}` cache-buster
       // still hits this handler.

--- a/src/packages/git-shim/TODO.md
+++ b/src/packages/git-shim/TODO.md
@@ -1,0 +1,1 @@
+1. more commands like git push/commit

--- a/src/packages/git-shim/clone-api.ts
+++ b/src/packages/git-shim/clone-api.ts
@@ -1,0 +1,73 @@
+import type { MemoryVolume } from "../../memory-volume";
+import type { GitCommand, GitRequest, GitProgress } from "./types";
+
+export class CloneApi implements GitCommand {
+  constructor(
+    private apiBase: string,
+    private rawBase: string,
+  ) {}
+
+  async execute(vol: MemoryVolume, request: GitRequest, progress: GitProgress) {
+    const ghMatch = request.url.match(/github\.com\/([^/]+)\/([^/.]+)/);
+    if (!ghMatch) {
+      progress.error(`'${request.url}' is not a GitHub URL`);
+      return;
+    }
+    const [, owner, repo] = ghMatch;
+    const token = request.token;
+    const headers: Record<string, string> = {
+      Accept: "application/vnd.github.v3+json",
+      "User-Agent": "nodepod-git",
+    };
+    if (token) headers.Authorization = `token ${token}`;
+
+    progress.send("Fetching repository info...\n");
+    const repoResp = await fetch(`${this.apiBase}/repos/${owner}/${repo}`, { headers });
+    if (!repoResp.ok) {
+      if (repoResp.status === 404) { progress.error(`repository '${request.url}' not found`); return; }
+      if (repoResp.status === 403) { progress.error("GitHub API rate limit exceeded. Set GITHUB_TOKEN for higher limits."); return; }
+      progress.error(`GitHub API error: ${repoResp.status}`); return;
+    }
+    const repoData = await repoResp.json();
+    let branch = request.branch;
+    if (branch === "main" && repoData.default_branch !== "main") branch = repoData.default_branch;
+
+    progress.send(`Fetching file tree (${branch})...\n`);
+    const treeResp = await fetch(`${this.apiBase}/repos/${owner}/${repo}/git/trees/${branch}?recursive=1`, { headers });
+    if (!treeResp.ok) { progress.error(`Remote branch '${branch}' not found`); return; }
+    const treeData = await treeResp.json();
+
+    const files: string[] = [];
+    for (const item of treeData.tree) {
+      if (item.type === "blob") files.push(item.path);
+    }
+
+    if (!vol.existsSync(request.targetDir)) vol.mkdirSync(request.targetDir, { recursive: true });
+
+    let fileCount = 0;
+    const BATCH = 10;
+    for (let i = 0; i < files.length; i += BATCH) {
+      const batch = files.slice(i, i + BATCH);
+      const results = await Promise.all(
+        batch.map(async (fp) => {
+          try {
+            const r = await fetch(`${this.rawBase}/${owner}/${repo}/${branch}/${fp}`);
+            if (!r.ok) return null;
+            return { path: fp, data: new Uint8Array(await r.arrayBuffer()) };
+          } catch { return null; }
+        }),
+      );
+      for (const res of results) {
+        if (!res) continue;
+        const fullPath = request.targetDir + "/" + res.path;
+        const dir = fullPath.substring(0, fullPath.lastIndexOf("/"));
+        if (dir && !vol.existsSync(dir)) vol.mkdirSync(dir, { recursive: true });
+        vol.writeFileSync(fullPath, res.data);
+        fileCount++;
+      }
+      progress.send(`\rReceiving objects: ${Math.min(i + BATCH, files.length)}/${files.length}`);
+    }
+    progress.send("\n");
+    progress.done(fileCount);
+  }
+}

--- a/src/packages/git-shim/clone-native.ts
+++ b/src/packages/git-shim/clone-native.ts
@@ -1,0 +1,66 @@
+import type { MemoryVolume } from "../../memory-volume";
+import type { GitCommand, GitRequest, GitProgress } from "./types";
+import { createFsAdapter } from "./fs-adapter";
+
+export class CloneNative implements GitCommand {
+  constructor(private corsProxy: string | undefined) {}
+
+  async execute(vol: MemoryVolume, request: GitRequest, progress: GitProgress) {
+    const git = await import("isomorphic-git");
+    const http = await import("isomorphic-git/http/web");
+    const fs = createFsAdapter(vol);
+
+    let cloneUrl = request.url;
+    if (!cloneUrl.endsWith(".git")) cloneUrl += ".git";
+
+    let lastPhase = "";
+
+    await git.clone({
+      fs,
+      http: (http as any).default || http,
+      dir: request.targetDir,
+      url: cloneUrl,
+      singleBranch: true,
+      depth: 1,
+      noCheckout: true,
+      corsProxy: this.corsProxy,
+      ...(request.token ? { onAuth: () => ({ username: request.token! }) } : {}),
+      onProgress: (evt: { phase: string; loaded: number; total: number }) => {
+        if (evt.phase !== lastPhase) {
+          if (lastPhase) progress.send("\n");
+          lastPhase = evt.phase;
+        }
+        if (evt.total > 0) {
+          const pct = Math.round((evt.loaded / evt.total) * 100);
+          progress.send(`\r${evt.phase}: ${pct}% (${evt.loaded}/${evt.total})`);
+        } else {
+          progress.send(`\r${evt.phase}: ${evt.loaded}`);
+        }
+      },
+      onMessage: (msg: string) => { progress.send(msg); },
+    });
+
+    if (lastPhase) progress.send("\n");
+
+    // Checkout working tree
+    progress.send("Checking out files...\n");
+    try {
+      await git.checkout({ fs, dir: request.targetDir, force: true });
+    } catch (checkoutErr: any) {
+      console.error("[nodepod:git] checkout failed:", checkoutErr?.message || checkoutErr);
+      try {
+        const files = await git.listFiles({ fs, dir: request.targetDir, ref: "HEAD" });
+        const headOid = await git.resolveRef({ fs, dir: request.targetDir, ref: "HEAD" });
+        for (const filepath of files) {
+          try {
+            const { blob } = await git.readBlob({ fs, dir: request.targetDir, oid: headOid, filepath });
+            const fullPath = request.targetDir + "/" + filepath;
+            const dir = fullPath.substring(0, fullPath.lastIndexOf("/"));
+            if (dir && !vol.existsSync(dir)) vol.mkdirSync(dir, { recursive: true });
+            vol.writeFileSync(fullPath, new Uint8Array(blob));
+          } catch {}
+        }
+      } catch {}
+    }
+  }
+}

--- a/src/packages/git-shim/fs-adapter.ts
+++ b/src/packages/git-shim/fs-adapter.ts
@@ -1,0 +1,57 @@
+import type { MemoryVolume } from "../../memory-volume";
+
+/**
+ * Creates an fs adapter for isomorphic-git from Nodepod's MemoryVolume.
+ */
+export function createFsAdapter(vol: MemoryVolume) {
+  function makeStat(fp: string) {
+    try {
+      const s = vol.statSync(fp);
+      const mt = typeof s.mtime === "number" ? s.mtime : Date.now();
+      return {
+        isFile: () => s.isFile, isDirectory: () => s.isDirectory, isSymbolicLink: () => false,
+        size: s.size || 0,
+        mtimeMs: mt, ctimeMs: mt, atimeMs: mt, birthtimeMs: mt,
+        mtime: new Date(mt), ctime: new Date(mt), atime: new Date(mt), birthtime: new Date(mt),
+        mode: s.isDirectory ? 0o40755 : 0o100644,
+        uid: 1, gid: 1, ino: 0, dev: 0, nlink: 1, rdev: 0, blksize: 4096, blocks: 0,
+      };
+    } catch {
+      const err: any = new Error(`ENOENT: '${fp}'`);
+      err.code = "ENOENT";
+      throw err;
+    }
+  }
+
+  return {
+    promises: {
+      readFile: async (fp: string, opts?: any) => {
+        try {
+          const enc = typeof opts === "string" ? opts : opts?.encoding;
+          if (enc) return vol.readFileSync(fp, enc);
+          const data = vol.readFileSync(fp);
+          return data instanceof Uint8Array ? new Uint8Array(data) : new TextEncoder().encode(data as string);
+        } catch {
+          const err: any = new Error(`ENOENT: '${fp}'`);
+          err.code = "ENOENT";
+          throw err;
+        }
+      },
+      writeFile: async (fp: string, data: any) => {
+        const dir = fp.substring(0, fp.lastIndexOf("/"));
+        if (dir && dir !== "/" && !vol.existsSync(dir)) vol.mkdirSync(dir, { recursive: true });
+        if (typeof data === "string") vol.writeFileSync(fp, data);
+        else vol.writeFileSync(fp, new Uint8Array(data));
+      },
+      unlink: async (fp: string) => { try { vol.unlinkSync(fp); } catch {} },
+      readdir: async (fp: string) => vol.readdirSync(fp) as string[],
+      mkdir: async (fp: string, opts?: any) => { if (!vol.existsSync(fp)) vol.mkdirSync(fp, opts); },
+      rmdir: async (fp: string) => { try { vol.rmdirSync(fp); } catch {} },
+      stat: async (fp: string) => makeStat(fp),
+      lstat: async (fp: string) => makeStat(fp),
+      readlink: async () => { const e: any = new Error("ENOENT"); e.code = "ENOENT"; throw e; },
+      symlink: async () => {},
+      chmod: async () => {},
+    },
+  };
+}

--- a/src/packages/git-shim/index.ts
+++ b/src/packages/git-shim/index.ts
@@ -1,0 +1,84 @@
+import type { MemoryVolume } from "../../memory-volume";
+import type { ProcessManager } from "../../threading/process-manager";
+import type { GitShimOptions, GitRequest, GitProgress, GitCommand, GitCloneRequestMessage } from "./types";
+import { GitMessageType } from "./types";
+import { CloneNative } from "./clone-native";
+import { CloneApi } from "./clone-api";
+
+export type { GitShimOptions, GitRequest, GitProgress, GitCommand } from "./types";
+export { GitMessageType } from "./types";
+export { createFsAdapter } from "./fs-adapter";
+
+/**
+ * GitShim — abstraction layer for git operations in Nodepod.
+ *
+ * Supports two modes:
+ * - 'native': uses isomorphic-git (real Git Smart HTTP protocol)
+ * - 'api': uses GitHub REST API + raw.githubusercontent.com
+ *
+ * Extensible — add new commands (pull, push, etc.) by implementing GitCommand.
+ */
+export class GitShim {
+  private commands = new Map<string, GitCommand>();
+
+  constructor(private opts: GitShimOptions) {
+    if (opts.mode === "native") {
+      this.commands.set("clone", new CloneNative(opts.corsProxy));
+    } else {
+      this.commands.set("clone", new CloneApi(
+        opts.apiBase ?? "https://api.github.com",
+        opts.rawBase ?? "https://raw.githubusercontent.com",
+      ));
+    }
+  }
+
+  registerCommand(name: string, command: GitCommand) {
+    this.commands.set(name, command);
+  }
+
+  getCommand(name: string): GitCommand | undefined {
+    return this.commands.get(name);
+  }
+
+  attach(vol: MemoryVolume, pm: ProcessManager) {
+    pm.on("spawn", (pid: number) => {
+      const handle = pm.getProcess(pid) as any;
+      if (!handle) return;
+
+      handle.on(GitMessageType.REQUEST, (msg: GitCloneRequestMessage) => {
+        const worker = handle.worker as Worker;
+        const clone = this.commands.get("clone");
+        if (!clone) return;
+
+        const progress: GitProgress = {
+          send: (data) => worker.postMessage({ type: GitMessageType.PROGRESS, data }),
+          done: (fileCount) => worker.postMessage({ type: GitMessageType.DONE, fileCount }),
+          error: (data) => worker.postMessage({ type: GitMessageType.ERROR, data }),
+        };
+
+        clone.execute(vol, msg, progress).then(() => {
+          let fileCount = 0;
+          const count = (dir: string) => {
+            try {
+              for (const entry of vol.readdirSync(dir) as string[]) {
+                if (entry === ".git") continue;
+                const full = dir === "/" ? `/${entry}` : `${dir}/${entry}`;
+                try {
+                  if (vol.statSync(full).isDirectory) count(full);
+                  else fileCount++;
+                } catch {}
+              }
+            } catch {}
+          };
+          count(msg.targetDir);
+          progress.done(fileCount);
+        }).catch((e: any) => {
+          const errMsg = e?.message || String(e);
+          if (errMsg.includes("404")) progress.error(`repository '${msg.url}' not found`);
+          else if (errMsg.includes("401") || errMsg.includes("403")) progress.error(`authentication failed for '${msg.url}'`);
+          else progress.error(errMsg);
+        });
+      });
+    });
+  }
+}

--- a/src/packages/git-shim/types.ts
+++ b/src/packages/git-shim/types.ts
@@ -1,0 +1,67 @@
+import type { MemoryVolume } from "../../memory-volume";
+
+export type GitMode = "api" | "native";
+
+// --- Worker ↔ Main thread message protocol ---
+
+export const GitMessageType = {
+  REQUEST: "git-clone-request",
+  PROGRESS: "git-clone-progress",
+  DONE: "git-clone-done",
+  ERROR: "git-clone-error",
+} as const;
+
+export interface GitCloneRequestMessage {
+  type: typeof GitMessageType.REQUEST;
+  url: string;
+  targetDir: string;
+  branch: string;
+  token: string | null;
+}
+
+export interface GitCloneProgressMessage {
+  type: typeof GitMessageType.PROGRESS;
+  data: string;
+}
+
+export interface GitCloneDoneMessage {
+  type: typeof GitMessageType.DONE;
+  fileCount: number;
+}
+
+export interface GitCloneErrorMessage {
+  type: typeof GitMessageType.ERROR;
+  data: string;
+}
+
+export type GitWorkerMessage = GitCloneProgressMessage | GitCloneDoneMessage | GitCloneErrorMessage;
+
+// --- Git command abstraction ---
+
+export interface GitRequest {
+  url: string;
+  targetDir: string;
+  branch: string;
+  token: string | null;
+}
+
+export interface GitProgress {
+  send(msg: string): void;
+  done(fileCount: number): void;
+  error(msg: string): void;
+}
+
+export interface GitShimOptions {
+  mode: GitMode;
+  corsProxy?: string;
+  apiBase?: string;
+  rawBase?: string;
+}
+
+export interface GitCommand {
+  execute(
+    vol: MemoryVolume,
+    request: GitRequest,
+    progress: GitProgress,
+  ): Promise<void>;
+}

--- a/src/packages/git-shim/worker-rpc.ts
+++ b/src/packages/git-shim/worker-rpc.ts
@@ -1,0 +1,45 @@
+import { GitMessageType } from "./types";
+import type { GitWorkerMessage } from "./types";
+
+/**
+ * Send a git clone request from the worker to the main thread
+ * and stream progress back to the caller.
+ */
+export function requestGitClone(
+  url: string,
+  targetDir: string,
+  branch: string,
+  token: string | null,
+  onProgress: (msg: string) => void,
+): Promise<{ fileCount: number }> {
+  return new Promise((resolve, reject) => {
+    const handler = (evt: MessageEvent) => {
+      const msg = evt.data as GitWorkerMessage;
+      if (!msg || typeof msg !== "object") return;
+
+      switch (msg.type) {
+        case GitMessageType.PROGRESS:
+          onProgress(msg.data);
+          break;
+        case GitMessageType.DONE:
+          self.removeEventListener("message", handler);
+          resolve({ fileCount: msg.fileCount });
+          break;
+        case GitMessageType.ERROR:
+          self.removeEventListener("message", handler);
+          reject(new Error(msg.data));
+          break;
+      }
+    };
+
+    self.addEventListener("message", handler);
+
+    (postMessage as any)({
+      type: GitMessageType.REQUEST,
+      url,
+      targetDir,
+      branch,
+      token,
+    });
+  });
+}

--- a/src/polyfills/buffer.ts
+++ b/src/polyfills/buffer.ts
@@ -76,7 +76,14 @@ class BufferPolyfill extends Uint8Array {
       return new BufferPolyfill(source as ArrayBuffer);
     }
 
-    return new BufferPolyfill(source as Uint8Array);
+    // Copy the data to avoid shared-buffer aliasing bugs when callers
+    // later call .write() or .set() with offsets.
+    const copy = new Uint8Array(
+      (source as Uint8Array).buffer,
+      (source as Uint8Array).byteOffset,
+      (source as Uint8Array).byteLength,
+    );
+    return new BufferPolyfill(copy.slice());
   }
 
   static alloc(len: number, fillValue?: number): BufferPolyfill {
@@ -163,18 +170,42 @@ class BufferPolyfill extends Uint8Array {
   write(string: string, encoding?: BufferEncoding): number;
   write(string: string, offset: number, encoding?: BufferEncoding): number;
   write(string: string, offset: number, length: number, encoding?: BufferEncoding): number;
+  // Override set() to handle edge cases with subarray views that cause
+  // "offset is out of bounds" errors in the native Uint8Array.set()
+  override set(array: ArrayLike<number>, offset?: number): void {
+    const off = offset || 0;
+    if (off + array.length > this.length) {
+      // Clamp instead of throwing
+      const len = this.length - off;
+      for (let i = 0; i < len; i++) {
+        this[off + i] = array[i]!;
+      }
+    } else {
+      super.set(array, off);
+    }
+  }
+
   write(string: string, offsetOrEncoding?: number | BufferEncoding, lengthOrEncoding?: number | BufferEncoding, _encoding?: BufferEncoding): number {
     const offset = typeof offsetOrEncoding === "number" ? offsetOrEncoding : 0;
     const encoded = textEnc.encode(string);
-    const len = typeof lengthOrEncoding === "number" ? Math.min(lengthOrEncoding, encoded.length) : encoded.length;
-    this.set(encoded.subarray(0, len), offset);
+    const len = typeof lengthOrEncoding === "number" ? Math.min(lengthOrEncoding, encoded.length, this.length - offset) : Math.min(encoded.length, this.length - offset);
+    if (len <= 0) return 0;
+    // Manual byte copy to avoid Uint8Array.set() bugs with subarray views
+    for (let i = 0; i < len; i++) {
+      this[offset + i] = encoded[i]!;
+    }
     return len;
   }
 
   copy(dest: BufferPolyfill, destStart?: number, srcStart?: number, srcEnd?: number): number {
-    const segment = this.subarray(srcStart || 0, srcEnd);
-    dest.set(segment, destStart || 0);
-    return segment.length;
+    const start = srcStart || 0;
+    const end = srcEnd ?? this.length;
+    const dStart = destStart || 0;
+    const len = Math.min(end - start, dest.length - dStart);
+    for (let i = 0; i < len; i++) {
+      dest[dStart + i] = this[start + i]!;
+    }
+    return len;
   }
 
   compare(other: Uint8Array): number {

--- a/src/polyfills/crypto.ts
+++ b/src/polyfills/crypto.ts
@@ -28,39 +28,38 @@ function hashOutputSize(alg: string): number {
   return 32;
 }
 
+// Real SHA-1/SHA-256 implementation via sha.js (pure JS, sync)
+import ShaJs from "sha.js";
+
 function mixHash(input: Uint8Array, alg: string): Uint8Array {
-  const size = hashOutputSize(alg);
-  const out = new Uint8Array(size);
-
-  let a = 0xdeadbeef | 0;
-  let b = 0x41c6ce57 | 0;
-
-  for (let i = 0; i < input.length; i++) {
-    a = Math.imul(a ^ input[i], 2654435761);
-    b = Math.imul(b ^ input[i], 1597334677);
-  }
-
-  a =
-    Math.imul(a ^ (a >>> 16), 2246822507) ^
-    Math.imul(b ^ (b >>> 13), 3266489909);
-  b =
-    Math.imul(b ^ (b >>> 16), 2246822507) ^
-    Math.imul(a ^ (a >>> 13), 3266489909);
-
-  for (let i = 0; i < size; i++) {
-    const source = i < size >>> 1 ? a : b;
-    out[i] = (source >>> ((i & 3) * 8)) & 0xff;
-    a = (Math.imul(a, 1103515245) + 12345) | 0;
-    b = (Math.imul(b, 1103515245) + 12345) | 0;
-  }
-  return out;
+  const shaAlg = alg === "SHA-1" ? "sha1" : alg === "SHA-256" ? "sha256" : alg.toLowerCase().replace("-", "");
+  return new Uint8Array((ShaJs as any)(shaAlg).update(input).digest());
 }
 
 function mixHmac(data: Uint8Array, key: Uint8Array, alg: string): Uint8Array {
-  const merged = new Uint8Array(key.length + data.length);
-  merged.set(key, 0);
-  merged.set(data, key.length);
-  return mixHash(merged, alg);
+  // Proper HMAC: H((K ^ opad) || H((K ^ ipad) || message))
+  const blockSize = 64;
+  let k = key;
+  if (k.length > blockSize) k = mixHash(k, alg);
+  const paddedKey = new Uint8Array(blockSize);
+  paddedKey.set(k);
+
+  const ipad = new Uint8Array(blockSize);
+  const opad = new Uint8Array(blockSize);
+  for (let i = 0; i < blockSize; i++) {
+    ipad[i] = paddedKey[i] ^ 0x36;
+    opad[i] = paddedKey[i] ^ 0x5c;
+  }
+
+  const inner = new Uint8Array(blockSize + data.length);
+  inner.set(ipad);
+  inner.set(data, blockSize);
+  const innerHash = mixHash(inner, alg);
+
+  const outer = new Uint8Array(blockSize + innerHash.length);
+  outer.set(opad);
+  outer.set(innerHash, blockSize);
+  return mixHash(outer, alg);
 }
 
 function joinChunks(parts: Uint8Array[]): Uint8Array {

--- a/src/sdk/nodepod.ts
+++ b/src/sdk/nodepod.ts
@@ -1,4 +1,5 @@
 import { MemoryVolume } from "../memory-volume";
+import { GitShim } from "../packages/git-shim";
 import { DependencyInstaller } from "../packages/installer";
 import {
   RequestProxy,
@@ -297,6 +298,15 @@ export class Nodepod {
         }
       }
     }
+
+    // Set up git shim (always registered — 'api' is the default)
+    const gitShim = new GitShim({
+      mode: opts.git === "native" ? "native" : "api",
+      corsProxy: opts.gitCorsProxy,
+      apiBase: opts.gitApiBase,
+      rawBase: opts.gitRawBase,
+    });
+    gitShim.attach(volume, nodepod.processManager);
 
     return nodepod;
   }

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -39,6 +39,15 @@ export interface NodepodOptions {
   /** domains allowed through the cors proxy. merged with built-in defaults
    *  (npm, github, esm.sh etc). pass null to allow everything */
   allowedFetchDomains?: string[] | null;
+  /** Git clone mode. `'native'` uses real Git Smart HTTP protocol via isomorphic-git.
+   *  `'api'` uses GitHub REST API (default). When `'native'`, set `gitCorsProxy` to the proxy path. */
+  git?: 'api' | 'native';
+  /** CORS proxy base URL for git native mode (e.g. "http://localhost:5180/__nodepod_git_proxy__"). */
+  gitCorsProxy?: string;
+  /** Override GitHub API base URL (for testing). Defaults to "https://api.github.com". */
+  gitApiBase?: string;
+  /** Override raw.githubusercontent.com base URL (for testing). Defaults to "https://raw.githubusercontent.com". */
+  gitRawBase?: string;
 }
 
 /* ---- Terminal ---- */

--- a/src/shell/commands/git.ts
+++ b/src/shell/commands/git.ts
@@ -8,6 +8,7 @@ import { VERSIONS } from "../../constants/config";
 import { proxiedFetch } from "../../cross-origin";
 import * as pathModule from "../../polyfills/path";
 import { createHash } from "../../polyfills/crypto";
+import { requestGitClone } from "../../packages/git-shim/worker-rpc";
 
 /* ------------------------------------------------------------------ */
 /*  ANSI helpers                                                       */
@@ -717,16 +718,18 @@ class GitRepo {
 
 async function githubApi(
   path: string,
-  token: string,
+  token: string | null,
   method = "GET",
   body?: any,
 ): Promise<{ ok: boolean; status: number; data: any }> {
   const url = `https://api.github.com${path}`;
   const headers: Record<string, string> = {
     Accept: "application/vnd.github.v3+json",
-    Authorization: `token ${token}`,
     "User-Agent": "nodepod-git",
   };
+  if (token) {
+    headers.Authorization = `token ${token}`;
+  }
   if (body) headers["Content-Type"] = "application/json";
 
   const resp = await proxiedFetch(url, {
@@ -1771,87 +1774,28 @@ async function gitClone(args: string[], ctx: ShellContext): Promise<ShellResult>
     return fail(`fatal: repository '${url}' is not a GitHub URL\n`, 128);
   }
 
-  const token = requireToken(ctx.env);
-  if (!token) {
-    return fail("fatal: authentication required. Set GITHUB_TOKEN environment variable.\n", 128);
-  }
-
   let targetDir = nonFlags[1] ?? gh.repo;
   if (!targetDir.startsWith("/")) targetDir = pathModule.resolve(ctx.cwd, targetDir);
 
-  const repoInfo = await githubApi(`/repos/${gh.owner}/${gh.repo}`, token);
-  if (!repoInfo.ok) {
-    if (repoInfo.status === 404) return fail(`fatal: repository '${url}' not found\n`, 128);
-    return fail(`fatal: GitHub API error: ${repoInfo.status} ${repoInfo.data?.message ?? ""}\n`, 128);
-  }
-  const defaultBranch = repoInfo.data.default_branch ?? "main";
-  if (branch === "main" && defaultBranch !== "main") branch = defaultBranch;
+  const token = requireToken(ctx.env);
 
-  const refResp = await githubApi(`/repos/${gh.owner}/${gh.repo}/git/ref/heads/${branch}`, token);
-  if (!refResp.ok) {
-    return fail(`fatal: Remote branch '${branch}' not found\n`, 128);
-  }
-  const commitSha = refResp.data.object.sha;
-
-  const commitResp = await githubApi(`/repos/${gh.owner}/${gh.repo}/git/commits/${commitSha}`, token);
-  if (!commitResp.ok) return fail(`fatal: could not fetch commit\n`, 128);
-  const treeSha = commitResp.data.tree.sha;
-
-  const treeResp = await githubApi(`/repos/${gh.owner}/${gh.repo}/git/trees/${treeSha}?recursive=1`, token);
-  if (!treeResp.ok) return fail(`fatal: could not fetch tree\n`, 128);
-
-  if (!ctx.volume.existsSync(targetDir)) ctx.volume.mkdirSync(targetDir, { recursive: true });
-
-  let fileCount = 0;
-  const blobs: Array<{ path: string; sha: string }> = [];
-  for (const item of treeResp.data.tree) {
-    if (item.type === "blob") {
-      blobs.push({ path: item.path, sha: item.sha });
-    }
-  }
-
-  const BATCH_SIZE = 10;
-  for (let i = 0; i < blobs.length; i += BATCH_SIZE) {
-    const batch = blobs.slice(i, i + BATCH_SIZE);
-    const results = await Promise.all(
-      batch.map((b) => githubApi(`/repos/${gh.owner}/${gh.repo}/git/blobs/${b.sha}`, token)),
-    );
-    for (let j = 0; j < batch.length; j++) {
-      const blobResp = results[j];
-      if (!blobResp.ok) continue;
-      const filePath = targetDir + "/" + batch[j].path;
-      const dir = filePath.substring(0, filePath.lastIndexOf("/"));
-      if (dir && !ctx.volume.existsSync(dir)) ctx.volume.mkdirSync(dir, { recursive: true });
-      let content: string;
-      if (blobResp.data.encoding === "base64") {
-        content = atob(blobResp.data.content.replace(/\n/g, ""));
-      } else {
-        content = blobResp.data.content;
+  const write = (text: string) => {
+    try {
+      if (typeof postMessage === "function") {
+        (postMessage as any)({ type: "stdout", data: text });
       }
-      ctx.volume.writeFileSync(filePath, content);
-      fileCount++;
-    }
+    } catch { /* not in worker */ }
+  };
+
+  write(`Cloning into '${targetDir.split("/").pop()}'...\n`);
+
+  try {
+    const result = await requestGitClone(url, targetDir, branch, token, write);
+    write(`\nReceiving objects: 100% (${result.fileCount}/${result.fileCount}), done.\n`);
+    return ok("");
+  } catch (e: any) {
+    return fail(`fatal: ${e.message}\n`, 128);
   }
-
-  const initResult = gitInit([], { ...ctx, cwd: targetDir });
-
-  const clonedRepo = new GitRepo(ctx.volume, targetDir, targetDir + "/.git");
-  clonedRepo.setConfigValue("remote.origin.url", url);
-  clonedRepo.setConfigValue("remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*");
-  clonedRepo.setConfigValue("branch." + branch + ".remote", "origin");
-  clonedRepo.setConfigValue("branch." + branch + ".merge", "refs/heads/" + branch);
-
-  clonedRepo.setHEAD("ref: refs/heads/" + branch);
-
-  clonedRepo.walkWorkTree(targetDir, "", (relPath, content) => {
-    clonedRepo.addToIndex(relPath, content);
-  });
-  const entries = clonedRepo.readIndex();
-  const treeHash = clonedRepo.buildTree(entries);
-  const cloneCommitHash = clonedRepo.createCommit(`Clone of ${url}`, null, treeHash);
-  clonedRepo.updateBranchRef(branch, cloneCommitHash);
-
-  return ok(`Cloning into '${nonFlags[1] ?? gh.repo}'...\nremote: Enumerating objects: ${fileCount}\nReceiving objects: 100% (${fileCount}/${fileCount}), done.\n`);
 }
 
 async function gitPush(args: string[], ctx: ShellContext): Promise<ShellResult> {

--- a/src/threading/process-handle.ts
+++ b/src/threading/process-handle.ts
@@ -265,6 +265,10 @@ export class ProcessHandle extends EventEmitter {
           break;
 
         default:
+          // Forward unknown message types as generic events
+          if (msg.type) {
+            this.emit(msg.type, msg);
+          }
           break;
       }
     });

--- a/vite.lib.config.js
+++ b/vite.lib.config.js
@@ -63,6 +63,12 @@ function inlineProcessWorkerPlugin() {
 
 export default defineConfig({
   plugins: [wasm(), topLevelAwait(), inlineProcessWorkerPlugin()],
+  resolve: {
+    alias: {
+      // isomorphic-git does require('crypto') — resolve to our polyfill
+      crypto: resolve(__dirname, "src/polyfills/crypto.ts"),
+    },
+  },
   worker: {
     format: "es",
     rollupOptions: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   plugins: [wasm(), topLevelAwait()],
   test: {
     include: ["src/**/*.test.ts"],
+    exclude: ["src/__tests__/e2e/**"],
     benchmark: {
       include: ["src/**/*.bench.ts"],
     },


### PR DESCRIPTION
This PR makes git integration more native because current implementation is API-heavy. The goal is to make a Nodepod to operate on `git` more natively - thanks to that we don't need a Github API at all.

Current solution is experimental AND does not cover all cases - currently it's focused on cloning repos. For example if clone happens via `native` then it do that thanks to `isomorphic-git` which is a great git implementation for node/browser. 

Constraints:
- Big repos cloning speed is not sufficient but during tests I saw that current impl also does not work best.

Notes: 
- I've added e2e tests to showcase it works. 

I think it's still experimental feature but looks like a big opportunity for the future. Nevertheless tests shows it works and locally I'm at least satisfied to make this PR to look for.