### PR TITLE
feat: add terminal custom command support

### DIFF
--- a/examples/custom-commands/index.html
+++ b/examples/custom-commands/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>nodepod custom commands</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: system-ui, sans-serif; background: #0d1117; color: #c9d1d9; height: 100vh; display: flex; flex-direction: column; }
+    header { padding: 12px 16px; background: #161b22; border-bottom: 1px solid #30363d; display: flex; align-items: center; gap: 12px; }
+    header h1 { font-size: 14px; font-weight: 600; }
+    header span { font-size: 12px; color: #8b949e; }
+    #terminal-box { flex: 1; min-height: 0; padding: 4px; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>nodepod</h1>
+    <span>custom terminal commands</span>
+  </header>
+  <div id="terminal-box"></div>
+
+  <script type="module">
+    import { Nodepod } from "/dist/index.mjs";
+    import { Terminal } from "https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/+esm";
+    import { FitAddon } from "https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/+esm";
+
+    const nodepod = await Nodepod.boot({
+      swUrl: "/__sw__.js",
+      workdir: "/home",
+      files: {
+        "/home/readme.txt": "custom commands run in the terminal host\n",
+      },
+    });
+
+    const terminal = nodepod.createTerminal({
+      Terminal,
+      FitAddon,
+      fontSize: 13,
+      fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
+      customCommands: {
+        help: () =>
+          [
+            "custom commands:",
+            "  help               show this message",
+            "  whereami           print the current terminal cwd",
+            "  greet <name...>    print parsed arguments",
+            "  fail               show thrown errors in the terminal",
+            "",
+            "built-ins still work: try pwd, ls, cat readme.txt, cd /",
+          ].join("\n") + "\n",
+        whereami: (cwd) => `${cwd}\n`,
+        greet: (cwd, args) => {
+          const name = args.join(" ") || "friend";
+          return `hello ${name} from ${cwd}\n`;
+        },
+        fail: () => {
+          throw new Error("custom command failures are printed as terminal errors");
+        },
+      },
+    });
+
+    terminal.attach(document.getElementById("terminal-box"));
+    terminal.writeln("Run help to see all commands.");
+    terminal.showPrompt();
+  </script>
+</body>
+</html>

--- a/examples/serve.js
+++ b/examples/serve.js
@@ -50,6 +50,7 @@ createServer((req, res) => {
   console.log(`  Vite build test:      http://localhost:${port}/examples/vite-build-test/`);
   console.log(`  Native WASI test:     http://localhost:${port}/examples/native-wasi-test/`);
   console.log(`  SW setup DX:          http://localhost:${port}/examples/sw-setup/`);
+  console.log(`  Custom commands:      http://localhost:${port}/examples/custom-commands/`);
   console.log(`  Terminal resize:      http://localhost:${port}/examples/terminal-resize/`);
   console.log(`  Shared FS attach:     http://localhost:${port}/examples/shared-fs-attach/`);
   console.log(`  SAB opt-out:          http://localhost:${port}/examples/sab-opt-out/`);

--- a/src/sdk/nodepod.ts
+++ b/src/sdk/nodepod.ts
@@ -19,6 +19,7 @@ import { NodepodFS } from "./nodepod-fs";
 import { NodepodProcess } from "./nodepod-process";
 import { NodepodTerminal } from "./nodepod-terminal";
 import { getCompletions } from "../shell/shell-completions";
+import { parse as parseShell } from "../shell/shell-parser";
 import { builtins as shellBuiltins } from "../shell/shell-builtins";
 import { ProcessManager } from "../threading/process-manager";
 import { setAllowedDomains } from "../cross-origin";
@@ -51,6 +52,23 @@ function shellQuote(arg: string): string {
   if (/^[A-Za-z0-9_\-./:=@%+,]+$/.test(arg)) return arg;
   // single-quote it, escape any inner quotes the posix way
   return "'" + arg.replace(/'/g, "'\\''") + "'";
+}
+
+function parseSimpleCommand(
+  input: string,
+  env: Record<string, string>,
+): { name: string; args: string[] } | null {
+  const ast = parseShell(input, env);
+  if (ast.entries.length !== 1 || ast.entries[0].next) return null;
+
+  const pipeline = ast.entries[0].pipeline;
+  if (pipeline.commands.length !== 1) return null;
+
+  const command = pipeline.commands[0];
+  if (command.redirects.length || command.args.length === 0) return null;
+
+  const [name, ...args] = command.args;
+  return { name, args };
 }
 
 export class Nodepod {
@@ -404,6 +422,8 @@ export class Nodepod {
   createTerminal(opts: TerminalOptions): NodepodTerminal {
     const terminal = new NodepodTerminal(opts);
     terminal.setCwd(this._cwd);
+    const customCommands = opts.customCommands ?? {};
+    const customCommandNames = Object.keys(customCommands);
 
     let activeAbort: AbortController | null = null;
     let currentSendStdin: ((data: string) => void) | null = null;
@@ -495,6 +515,31 @@ export class Nodepod {
             wroteNewline = true;
             terminal.write("\r\n");
           }
+        }
+
+        const simpleCommand = parseSimpleCommand(cmd, this._env);
+        if (simpleCommand && customCommands[simpleCommand.name]) {
+          try {
+            const output = customCommands[simpleCommand.name](
+              terminal.getCwd(),
+              simpleCommand.args,
+            );
+            if (output) {
+              ensureNewline();
+              terminal._writeOutput(output);
+            }
+          } catch (err) {
+            ensureNewline();
+            const message = err instanceof Error ? err.message : String(err);
+            terminal._writeOutput(`${simpleCommand.name}: ${message}\n`, true);
+          } finally {
+            if (activeAbort === myAbort) activeAbort = null;
+            currentSendStdin = null;
+            if (!wroteNewline) terminal.write("\r\n");
+            terminal._setRunning(false);
+            terminal._writePrompt();
+          }
+          return;
         }
 
         // Ensure persistent shell worker is running
@@ -611,7 +656,9 @@ export class Nodepod {
         activeAbort = ac;
       },
       getCompletions: (line: string, cursorPos: number, cwd: string) =>
-        getCompletions(line, cursorPos, cwd, this._volume, shellBuiltins.keys()),
+        getCompletions(line, cursorPos, cwd, this._volume, shellBuiltins.keys(), {
+          extraCommands: customCommandNames,
+        }),
       onResize: forwardResize,
     });
 

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -76,6 +76,7 @@ export interface TerminalOptions {
   fontSize?: number;
   fontFamily?: string;
   prompt?: (cwd: string) => string;
+  customCommands?: Record<string, (cwd: string, args: string[]) => string>;
 }
 
 /* ---- Filesystem ---- */


### PR DESCRIPTION
This allows users to define their own custom shell commands for each terminal. This is useful for me because I wanted to communicate with my ui when the user ran some specific commands.