### PR TITLE
fix: route wasi fs proxy via messageport for chrome (#54)

### DIFF
--- a/src/helpers/napi-wasm-worker.ts
+++ b/src/helpers/napi-wasm-worker.ts
@@ -159,6 +159,75 @@ try {
 
 let _nextWasiThreadId = 100;
 
+// chrome silently drops `new Worker()` if the parent web worker is about to
+// enter Atomics.wait (tailwind oxide does this back to back in
+// instantiateNapiModuleSync). pre-spawn empty workers while the spawned
+// process boots so theyre already running before anyone blocks, then inject
+// the actual bundle via importScripts when napi-rs needs one.
+const _wasiPool: globalThis.Worker[] = [];
+const _WASI_POOL_TARGET = 8;
+let _poolPreambleUrl: string | null = null;
+
+function getPoolPreambleUrl(): string {
+  if (_poolPreambleUrl) return _poolPreambleUrl;
+  const src = `
+    self.onmessage = function(e) {
+      var d = e && e.data;
+      if (d && d.__nodepod_init_bundle__) {
+        var url = d.bundleUrl;
+        // stash transferred fs port for the bundle preamble to pick up
+        if (d.fsPort) {
+          globalThis.__nodepodWasiFsPort = d.fsPort;
+          try { d.fsPort.start(); } catch (_) {}
+        }
+        try {
+          self.onmessage = null;
+          importScripts(url);
+        } catch (err) {
+          try { self.postMessage({ __nodepod_pool_err__: String(err && err.message || err) }); } catch (_) {}
+        }
+      }
+    };
+  `;
+  const blob = new Blob([src], { type: "application/javascript" });
+  _poolPreambleUrl = URL.createObjectURL(blob);
+  return _poolPreambleUrl;
+}
+
+function refillPool(): void {
+  while (_wasiPool.length < _WASI_POOL_TARGET) {
+    try {
+      _wasiPool.push(new globalThis.Worker(getPoolPreambleUrl(), { name: "wasi-pool" }));
+    } catch {
+      break;
+    }
+  }
+}
+
+function pullFromPool(): globalThis.Worker | null {
+  if (_wasiPool.length < _WASI_POOL_TARGET / 2) {
+    queueMicrotask(refillPool);
+  }
+  return _wasiPool.shift() ?? null;
+}
+
+// call early in spawned-process boot, before anything blocks
+export function prewarmWasiPool(): void {
+  refillPool();
+}
+
+// MessagePort pool from the tab. each port is a 1:1 fs proxy channel for one
+// WASI worker. sidesteps chrome dropping BroadcastChannel messages from blob
+// workers, and works when the parent is in sync wasm (oxide.scan).
+const _wasiFsPortPool: MessagePort[] = [];
+export function setWasiFsPortPool(ports: MessagePort[]): void {
+  _wasiFsPortPool.length = 0;
+  for (const p of ports) _wasiFsPortPool.push(p);
+}
+function pullFsPort(): MessagePort | null {
+  return _wasiFsPortPool.shift() ?? null;
+}
+
 /**
  * makes a PatchedWorker constructor that spawns real browser Web Workers for
  * napi-rs WASI scripts, falling back to the standard fork-based worker otherwise
@@ -296,42 +365,61 @@ function createRealWebWorker(
     }
   }
 
-  // blob URL + real Web Worker
   let realWorker: globalThis.Worker;
+  let blobUrl: string;
   try {
     const blob = new Blob([bundleSource], { type: "application/javascript" });
-    const blobUrl = URL.createObjectURL(blob);
-    realWorker = new globalThis.Worker(blobUrl, { name: `napi-wasi-${self.threadId}` });
-    // revoke after worker has had time to start
-    setTimeout(() => URL.revokeObjectURL(blobUrl), 5000);
+    blobUrl = URL.createObjectURL(blob);
   } catch (err: any) {
     queueMicrotask(() =>
-      self.emit(
-        "error",
-        new Error(`Failed to create WASI Web Worker: ${err.message}`),
-      ),
+      self.emit("error", new Error(`Failed to build WASI bundle: ${err.message}`)),
     );
     return;
   }
 
-  // bridge: real Web Worker <-> Node.js Worker API
+  const pooled = pullFromPool();
+  if (pooled) {
+    realWorker = pooled;
+    const fsPort = pullFsPort();
+    try {
+      const initMsg: any = { __nodepod_init_bundle__: true, bundleUrl: blobUrl };
+      if (fsPort) {
+        initMsg.fsPort = fsPort;
+        realWorker.postMessage(initMsg, [fsPort]);
+      } else {
+        realWorker.postMessage(initMsg);
+      }
+    } catch { /* ignore */ }
+    setTimeout(() => URL.revokeObjectURL(blobUrl), 5000);
+  } else {
+    // pool empty, direct spawn. hits the chrome quirk if parent is about to
+    // block but at least non-blocking cases still work.
+    try {
+      realWorker = new globalThis.Worker(blobUrl, { name: `napi-wasi-${self.threadId}` });
+      setTimeout(() => URL.revokeObjectURL(blobUrl), 5000);
+    } catch (err: any) {
+      queueMicrotask(() =>
+        self.emit(
+          "error",
+          new Error(`Failed to create WASI Web Worker: ${err.message}`),
+        ),
+      );
+      return;
+    }
+  }
+
   realWorker.onmessage = (e: MessageEvent) => {
     const data = e.data;
-
-    // __fs__ protocol: fs proxy requests from the worker
     if (data && typeof data === "object" && data.__fs__) {
       handleFsProxy(data.__fs__, fsBridge);
       return;
     }
-
     self.emit("message", data);
   };
 
   realWorker.onerror = (e: ErrorEvent) => {
     self.emit("error", new Error(e.message || "Worker error"));
-    // web workers don't emit exit, so on an unhandled error close the
-    // handle ourselves and fake exit code 1 to match node. otherwise a
-    // crashed wasi worker leaks the loop ref forever.
+    // web workers dont emit exit, fake one so the loop ref isnt leaked
     if (!self._terminated) {
       (self._elHandle as Handle | null)?.close();
       self._elHandle = null;
@@ -359,10 +447,11 @@ function createRealWebWorker(
     if (!self._terminated) (self._elHandle as Handle | null)?.ref();
     return self;
   };
-  self.unref = () => {
-    (self._elHandle as Handle | null)?.unref();
-    return self;
-  };
+  // napi-rs's wasi.cjs calls worker.unref() to mirror node behavior where the
+  // http server keeps the loop alive. in nodepod the spawned process loop
+  // would drain before vite even binds, so we ignore unref. terminate/onExit
+  // still close the handle so the loop drains once the worker is done.
+  self.unref = () => self;
 
   // start reffed like Node.js does
   self._elHandle = getRegistry().register("Worker");
@@ -850,9 +939,11 @@ __pathStub.posix = __pathStub;
 //   [3] = reserved
 const __FS_DEFAULT_SAB = 16 + 65536; // 16 header + 64KB payload (enough for most ops)
 
-// fs proxy goes through BroadcastChannel direct to the browser tab so we
-// dont deadlock when the spawned process is busy in sync WASM (oxide.scan
-// etc). unref the channel because BroadcastChannel pins the event loop.
+// fs proxy: try dedicated MessagePort first (transferred from tab via the pool
+// init message, direct 1:1 channel, works in chrome where BC from blob workers
+// is broken). fall through to BC (firefox path) and parent postMessage (works
+// when parent isnt in sync wasm). first one to flip the SAB status wins.
+const __wasiFsPort = globalThis.__nodepodWasiFsPort || null;
 const __wasiFsBC = (typeof BroadcastChannel !== 'undefined') ? new BroadcastChannel('nodepod-wasi-fs') : null;
 if (__wasiFsBC && typeof __wasiFsBC.unref === 'function') {
   try { __wasiFsBC.unref(); } catch {}
@@ -866,13 +957,13 @@ function __fsSyncCall(type, args, sabSize) {
 
   const message = { __fs__: { sab: ctrl, type: type, payload: args || [] } };
 
-  if (__wasiFsBC) {
-    __wasiFsBC.postMessage(message);
-  } else {
-    // fallback for environments without BroadcastChannel. only works when
-    // the parent process isnt blocked.
-    __nativePostMessage(message);
+  if (__wasiFsPort) {
+    try { __wasiFsPort.postMessage(message); } catch {}
   }
+  if (__wasiFsBC) {
+    try { __wasiFsBC.postMessage(message); } catch {}
+  }
+  __nativePostMessage(message);
 
   const result = Atomics.wait(ctrl, 0, -1, 30000); // 30s timeout
   if (result === 'timed-out') {

--- a/src/script-engine.ts
+++ b/src/script-engine.ts
@@ -94,7 +94,7 @@ import * as seaPolyfill from "./polyfills/sea";
 import * as sqlitePolyfill from "./polyfills/sqlite";
 import * as quicPolyfill from "./polyfills/quic";
 import * as lightningcssPolyfill from "./polyfills/lightningcss";
-import { createNapiWorkerFactory, isNapiWasiWorkerScript } from "./helpers/napi-wasm-worker";
+import { createNapiWorkerFactory, isNapiWasiWorkerScript, prewarmWasiPool } from "./helpers/napi-wasm-worker";
 import {
   promises as streamPromises,
   Readable,
@@ -2135,6 +2135,9 @@ export class ScriptEngine {
       threadPoolPolyfill.setWorkerConstructorOverride((self, script, opts) => {
         workerFactory.call(self, script, opts);
       });
+      // prewarm now while the parent thread is free. chrome wont schedule
+      // child workers spawned from a parent thats about to Atomics.wait
+      try { prewarmWasiPool(); } catch (err) { _nativeConsole.warn("[Nodepod] WASI pool prewarm failed:", err); }
     }
 
     // Intercept fetch() for file:// URLs — serve from VFS instead of network.

--- a/src/threading/process-handle.ts
+++ b/src/threading/process-handle.ts
@@ -70,11 +70,12 @@ export class ProcessHandle extends EventEmitter {
     this.worker.postMessage(msg, transfer ?? []);
   }
 
-  init(initMsg: MainToWorker_Init): void {
+  init(initMsg: MainToWorker_Init, extraTransfer?: Transferable[]): void {
     const transfer: Transferable[] = [];
     if (initMsg.snapshot.data.byteLength > 0) {
       transfer.push(initMsg.snapshot.data);
     }
+    if (extraTransfer) transfer.push(...extraTransfer);
     this.postMessage(initMsg, transfer);
   }
 

--- a/src/threading/process-manager.ts
+++ b/src/threading/process-manager.ts
@@ -4,6 +4,8 @@
 import { EventEmitter } from "../polyfills/events";
 import type { MemoryVolume } from "../memory-volume";
 import { ProcessHandle } from "./process-handle";
+import { buildFileSystemBridge } from "../polyfills/fs";
+import { handleFsProxy } from "../helpers/napi-wasm-worker";
 import type {
   SpawnConfig,
   ProcessInfo,
@@ -105,6 +107,28 @@ export class ProcessManager extends EventEmitter {
     this._processes.set(pid, handle);
     this._wireHandleEvents(handle);
 
+    // pool of fs proxy MessagePorts for the spawned process to hand out to
+    // its WASI workers. one port per worker, tab side handles each. chrome
+    // drops BroadcastChannel delivery from blob workers so we cant rely on
+    // that as the only route (#54 follow-up).
+    const wasiFsPorts: MessagePort[] = [];
+    const transferPorts: MessagePort[] = [];
+    {
+      const tabFsBridge = buildFileSystemBridge(this._volume, () => "/");
+      const POOL_SIZE = 16;
+      for (let i = 0; i < POOL_SIZE; i++) {
+        const ch = new MessageChannel();
+        ch.port1.onmessage = (e: MessageEvent) => {
+          const data = e.data;
+          if (!data || typeof data !== "object" || !data.__fs__) return;
+          handleFsProxy(data.__fs__, tabFsBridge);
+        };
+        ch.port1.start();
+        transferPorts.push(ch.port2);
+        wasiFsPorts.push(ch.port2);
+      }
+    }
+
     const initMsg: MainToWorker_Init = {
       type: "init",
       pid,
@@ -113,8 +137,9 @@ export class ProcessManager extends EventEmitter {
       snapshot: spawnConfig.snapshot,
       sharedBuffer: spawnConfig.sharedBuffer,
       syncBuffer: spawnConfig.syncBuffer,
+      wasiFsPorts,
     };
-    handle.init(initMsg);
+    handle.init(initMsg, transferPorts);
 
     this.emit("spawn", pid, config.command, config.args);
     return handle;

--- a/src/threading/process-worker-entry.ts
+++ b/src/threading/process-worker-entry.ts
@@ -188,6 +188,14 @@ function handleInit(msg: MainToWorker_Init): void {
   // if main had SAB off, neither buffer was sent
   _sabEnabled = !!msg.syncBuffer;
 
+  // fs proxy ports from the tab, hand them to napi-wasm-worker for WASI
+  // workers to grab when they spawn. chrome BC workaround (#54 follow-up)
+  if (msg.wasiFsPorts && msg.wasiFsPorts.length > 0) {
+    import("../helpers/napi-wasm-worker").then((m) => {
+      m.setWasiFsPortPool(msg.wasiFsPorts!);
+    }).catch(() => {});
+  }
+
   _initialized = true;
   post({ type: "ready", pid: _pid });
 }

--- a/src/threading/worker-protocol.ts
+++ b/src/threading/worker-protocol.ts
@@ -25,6 +25,9 @@ export interface MainToWorker_Init {
   snapshot: VFSBinarySnapshot;
   sharedBuffer?: SharedArrayBuffer;
   syncBuffer?: SharedArrayBuffer;
+  // tab-side fs proxy ports, one per WASI worker the spawned process will
+  // create. chrome BC workaround (see process-manager spawn). #54 follow-up
+  wasiFsPorts?: MessagePort[];
 }
 
 export interface MainToWorker_Exec {


### PR DESCRIPTION
vite 8 + react + tailwind v4 still hung in chrome (issue #54 was only fixed for firefox). two chrome quirks behind it:

1. broadcastchannel postmessage from a blob-url web worker doesnt deliver to the main tab subscriber, even same-origin and cross-origin-isolated. firefox does deliver it.
2. `new Worker()` called from a web worker thats about to enter Atomics.wait gets silently dropped. tailwind oxides instantiateNapiModuleSync hits this exact case (onCreateWorker then atomics.wait back to back).

fix:

- prewarm a pool of empty web workers at spawned-process boot, before anything blocks. when napi-rs needs a wasi worker, pull one from the pool and importScripts the actual bundle. workers are already running so chrome doesnt need to schedule them against a blocked parent.
- per-spawn, the tab creates 16 messagechannels and transfers one end of each to the spawned process via the init message. each WASI worker grabs a port and uses it as the primary fs proxy route. broadcastchannel + parent postmessage stay as fallbacks. messageport is direct chrome IPC so the BC delivery quirk doesnt apply.
- ignore worker.unref() for wasi workers. napi-rs calls it intentionally to mirror node behavior where the http server keeps the loop alive, but in nodepod the spawned process loop drains before vite even binds.