### PR TITLE
fix: prefer node_modules paths in require.resolve for core module names

### DIFF
--- a/src/__tests__/integrations/vite-dev-startup.test.ts
+++ b/src/__tests__/integrations/vite-dev-startup.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Reproduces the original sandbox failure: `npm run dev` / `node node_modules/vite/bin/vite.js`
+ * crashed with ENOENT on `/package.json` because require.resolve('rollup') returned the bare
+ * specifier "rollup" instead of a filesystem path inside node_modules.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { MemoryVolume } from "../../memory-volume";
+import {
+  executeNodeBinary,
+  initShellExec,
+  shellExec,
+} from "../../polyfills/child_process";
+import type { ShellContext } from "../../shell/shell-types";
+
+const repoRoot = path.resolve(
+  fileURLToPath(import.meta.url),
+  "../../..",
+);
+const hostRequire = createRequire(path.join(repoRoot, "package.json"));
+
+const PROJECT = "/project";
+
+function copyHostTree({
+  hostDir,
+  vfsDir,
+  vol,
+}: {
+  hostDir: string;
+  vfsDir: string;
+  vol: MemoryVolume;
+}): void {
+  const realDir = fs.realpathSync(hostDir);
+  for (const entry of fs.readdirSync(realDir, { withFileTypes: true })) {
+    const hostPath = path.join(realDir, entry.name);
+    const vfsPath = `${vfsDir}/${entry.name}`;
+    if (entry.isDirectory()) {
+      vol.mkdirSync(vfsPath, { recursive: true });
+      copyHostTree({ hostDir: hostPath, vfsDir: vfsPath, vol });
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    vol.writeFileSync(vfsPath, fs.readFileSync(hostPath));
+  }
+}
+
+function seedHostPackage({
+  name,
+  vfsDir,
+  vol,
+  seen,
+}: {
+  name: string;
+  vfsDir: string;
+  vol: MemoryVolume;
+  seen: Set<string>;
+}): void {
+  if (seen.has(name)) return;
+  seen.add(name);
+
+  let pkgJsonHost: string;
+  try {
+    pkgJsonHost = hostRequire.resolve(`${name}/package.json`);
+  } catch {
+    return;
+  }
+
+  const pkgRoot = path.dirname(pkgJsonHost);
+  copyHostTree({ hostDir: pkgRoot, vfsDir: `${vfsDir}/${name}`, vol });
+
+  const manifest = JSON.parse(fs.readFileSync(pkgJsonHost, "utf8")) as {
+    dependencies?: Record<string, string>;
+    optionalDependencies?: Record<string, string>;
+  };
+  for (const dep of Object.keys(manifest.dependencies ?? {})) {
+    seedHostPackage({ name: dep, vfsDir, vol, seen });
+  }
+  for (const dep of Object.keys(manifest.optionalDependencies ?? {})) {
+    try {
+      seedHostPackage({ name: dep, vfsDir, vol, seen });
+    } catch {
+      /* optional */
+    }
+  }
+}
+
+function createSampleViteProject(): {
+  vol: MemoryVolume;
+  ctx: ShellContext;
+} {
+  const vol = new MemoryVolume();
+  vol.mkdirSync(PROJECT, { recursive: true });
+
+  vol.writeFileSync(
+    `${PROJECT}/package.json`,
+    JSON.stringify(
+      {
+        name: "vite-sandbox-app",
+        private: true,
+        type: "module",
+        scripts: {
+          dev: "node node_modules/vite/bin/vite.js --host 0.0.0.0 --port 5173",
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  vol.writeFileSync(
+    `${PROJECT}/index.html`,
+    `<!DOCTYPE html>
+<html lang="en">
+  <head><meta charset="UTF-8" /><title>Vite sandbox</title></head>
+  <body><div id="app"></div><script type="module" src="/src/main.js"></script></body>
+</html>`,
+  );
+
+  vol.writeFileSync(
+    `${PROJECT}/src/main.js`,
+    `document.getElementById("app").textContent = "hello";`,
+  );
+
+  seedHostPackage({
+    name: "vite",
+    vfsDir: `${PROJECT}/node_modules`,
+    vol,
+    seen: new Set(),
+  });
+
+  initShellExec(vol, { cwd: PROJECT });
+  const ctx: ShellContext = {
+    cwd: PROJECT,
+    env: { HOME: "/home", PATH: "/usr/bin", PWD: PROJECT },
+    volume: vol,
+    exec: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
+  };
+
+  return { vol, ctx };
+}
+
+function runShell(
+  cmd: string,
+  cwd: string,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  return new Promise((resolve) => {
+    shellExec(cmd, { cwd }, (err, stdout, stderr) => {
+      resolve({
+        stdout: String(stdout ?? ""),
+        stderr: String(stderr ?? ""),
+        exitCode: err ? ((err as { code?: number }).code ?? 1) : 0,
+      });
+    });
+  });
+}
+
+let viteAvailable = false;
+let sampleProject: ReturnType<typeof createSampleViteProject> | undefined;
+
+beforeAll(() => {
+  try {
+    hostRequire.resolve("vite/package.json");
+    viteAvailable = true;
+    sampleProject = createSampleViteProject();
+  } catch {
+    viteAvailable = false;
+  }
+});
+
+describe("integrations/vite dev startup", () => {
+  it("sample project with seeded node_modules starts vite CLI", async () => {
+    if (!viteAvailable || !sampleProject) {
+      return expect(true).toBe(true);
+    }
+
+    const { ctx, vol } = sampleProject;
+    const pkg = JSON.parse(
+      vol.readFileSync(`${PROJECT}/package.json`, "utf8") as string,
+    ) as { scripts: { dev: string } };
+
+    expect(pkg.scripts.dev).toBe(
+      "node node_modules/vite/bin/vite.js --host 0.0.0.0 --port 5173",
+    );
+    expect(vol.existsSync(`${PROJECT}/node_modules/vite/bin/vite.js`)).toBe(
+      true,
+    );
+    expect(vol.existsSync(`${PROJECT}/node_modules/rollup/package.json`)).toBe(
+      true,
+    );
+
+    // Same binary as scripts.dev. --version loads vite's dependency graph (including
+    // resolveDependencyVersion("rollup")) and exits without keeping a dev server alive.
+    const result = await executeNodeBinary(
+      "node_modules/vite/bin/vite.js",
+      ["--version"],
+      ctx,
+    );
+
+    expect(result.stderr).not.toMatch(/ENOENT.*\/package\.json/);
+    expect(result.stderr).not.toMatch(
+      /no such file or directory.*\/package\.json/i,
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toMatch(/vite\/v?\d+\.\d+/i);
+  }, 120_000);
+
+  it("shell runs the package.json dev entrypoint command", async () => {
+    if (!viteAvailable || !sampleProject) {
+      return expect(true).toBe(true);
+    }
+
+    const result = await runShell(
+      "node node_modules/vite/bin/vite.js --version",
+      PROJECT,
+    );
+
+    expect(result.stderr).not.toMatch(/ENOENT.*\/package\.json/);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toMatch(/vite\/v?\d+\.\d+/i);
+  }, 30_000);
+});

--- a/src/__tests__/require-resolve-bare.test.ts
+++ b/src/__tests__/require-resolve-bare.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { ScriptEngine } from "../script-engine";
+import { MemoryVolume } from "../memory-volume";
+
+describe("require.resolve bare package names", () => {
+  it("resolves installed packages to filesystem paths, not bare specifiers", () => {
+    const vol = new MemoryVolume();
+    vol.mkdirSync("/project/node_modules/rollup/dist", { recursive: true });
+    vol.writeFileSync(
+      "/project/node_modules/rollup/package.json",
+      JSON.stringify({
+        name: "rollup",
+        version: "4.0.0",
+        main: "dist/rollup.js",
+      }),
+    );
+    vol.writeFileSync(
+      "/project/node_modules/rollup/dist/rollup.js",
+      "module.exports = {};",
+    );
+
+    const engine = new ScriptEngine(vol, { cwd: "/project" });
+    const result = engine.execute(
+      `
+      const bare = require.resolve('rollup');
+      const subpath = require.resolve('rollup/dist/rollup.js');
+      const path = require('path');
+      const brokenPkg = path.resolve(bare, '../../package.json');
+      module.exports = { bare, subpath, brokenPkg };
+    `,
+      "/project/test.js",
+    );
+
+    const { bare, subpath, brokenPkg } = result.exports as {
+      bare: string;
+      subpath: string;
+      brokenPkg: string;
+    };
+
+    expect(bare).toBe("/project/node_modules/rollup/dist/rollup.js");
+    expect(subpath).toBe("/project/node_modules/rollup/dist/rollup.js");
+    expect(brokenPkg).toBe("/project/node_modules/rollup/package.json");
+  });
+});

--- a/src/script-engine.ts
+++ b/src/script-engine.ts
@@ -1177,6 +1177,7 @@ function buildResolver(
     id: string,
     fromDir: string,
     preferEsm: boolean = false,
+    preferFilesystem: boolean = false,
   ): string => {
     if (typeof id !== "string") {
       throw new TypeError(
@@ -1206,12 +1207,13 @@ function buildResolver(
     if (id.includes("\\")) id = id.replace(/\\/g, "/");
 
     if (
-      CORE_MODULES[id] ||
-      id === "fs" ||
-      id === "process" ||
-      id === "url" ||
-      id === "querystring" ||
-      id === "util"
+      !preferFilesystem &&
+      (CORE_MODULES[id] ||
+        id === "fs" ||
+        id === "process" ||
+        id === "url" ||
+        id === "querystring" ||
+        id === "util")
     ) {
       return id;
     }
@@ -1850,10 +1852,24 @@ function buildResolver(
           err.code = "MODULE_NOT_FOUND";
           throw err;
         }
+        const resolveFilename = (fromDir: string): string => {
+          try {
+            return resolveId(request, fromDir, false, true);
+          } catch {
+            if (
+              request === "fs" ||
+              request === "process" ||
+              CORE_MODULES[request]
+            ) {
+              return request;
+            }
+            throw new Error(`Cannot find module '${request}'`);
+          }
+        };
         if (options?.paths && Array.isArray(options.paths)) {
           for (const p of options.paths) {
             try {
-              return resolveId(request, p);
+              return resolveFilename(p);
             } catch {
               /* try next */
             }
@@ -1865,7 +1881,7 @@ function buildResolver(
               const dir = p.endsWith("/node_modules")
                 ? pathPolyfill.dirname(p)
                 : p;
-              return resolveId(request, dir);
+              return resolveFilename(dir);
             } catch {
               /* try next */
             }
@@ -1875,7 +1891,7 @@ function buildResolver(
           ? pathPolyfill.dirname(parent.filename)
           : baseDir;
         try {
-          return resolveId(request, fromDir);
+          return resolveFilename(fromDir);
         } catch {
           const err: any = new Error(`Cannot find module '${request}'`);
           err.code = "MODULE_NOT_FOUND";
@@ -2042,17 +2058,24 @@ function buildResolver(
   };
 
   resolver.resolve = (id: string, options?: { paths?: string[] }): string => {
-    if (id === "fs" || id === "process" || CORE_MODULES[id]) return id;
     if (options?.paths && Array.isArray(options.paths)) {
       for (const p of options.paths) {
         try {
-          return resolveId(id, p);
+          return resolveId(id, p, false, true);
         } catch {
           /* try next */
         }
       }
     }
-    return resolveId(id, baseDir);
+    try {
+      return resolveId(id, baseDir, false, true);
+    } catch {
+      /* fall through to built-in bare names */
+    }
+    if (id === "fs" || id === "process" || CORE_MODULES[id]) return id;
+    const err: any = new Error(`Cannot find module '${id}'`);
+    err.code = "MODULE_NOT_FOUND";
+    throw err;
   };
 
   resolver.cache = cache;


### PR DESCRIPTION
Fixes [#72](https://github.com/R1ck404/Nodepod/issues/72) — `require.resolve('rollup')` returns bare specifier, breaking Vite dev server startup.

## Summary

- Fix `require.resolve()` returning bare specifiers (e.g. `"rollup"`) for packages that exist in `node_modules` but are also Nodepod core polyfills
- Vite failed on startup with `ENOENT: no such file or directory, open '/package.json'` because it walked up from the bare `"rollup"` path to `/package.json`
- `require.resolve()` and `Module._resolveFilename` now prefer filesystem resolution in `node_modules`, falling back to bare builtin names only when nothing is installed

## Problem

Running `npm run dev` inside a Nodepod sandbox crashed immediately:

```
Error: ENOENT: no such file or directory, open '/package.json'
```

Vite's `dep-BK3b2jBa.js` chunk calls `resolveDependencyVersion("rollup")`, which does:

```js
path.resolve(require.resolve("rollup"), "../../package.json")
```

Before this fix, `require.resolve("rollup")` returned `"rollup"` → `/package.json` (does not exist).

## Solution

Added a `preferFilesystem` flag to `resolveId()` used by `resolver.resolve` and `Module._resolveFilename`:

1. Try resolving via `node_modules` first
2. Fall back to bare core-module names (`"rollup"`, `"path"`, etc.) only if not installed

`require("rollup")` behavior is unchanged — it still loads the polyfill when appropriate. Only **resolve** paths are affected.

## Tests

- `src/__tests__/require-resolve-bare.test.ts` — unit test asserting `require.resolve('rollup')` returns a filesystem path
- `src/__tests__/integrations/vite-dev-startup.test.ts` — seeds a sample Vite project (package.json, index.html, host `node_modules`) and runs the Vite CLI without `/package.json` ENOENT

```bash
npm test -- src/__tests__/require-resolve-bare.test.ts src/__tests__/integrations/vite-dev-startup.test.ts
```

## Test plan

- [x] `require-resolve-bare.test.ts` passes
- [x] `vite-dev-startup.test.ts` passes (direct CLI + shell entrypoint)
- [x] `script-engine.test.ts` passes (no regressions)
- [ ] Manual: boot Nodepod sandbox, `npm install`, `npm run dev` with Vite project

Closes #72
