### PR TITLE
feat: Node-compatible import.meta.resolve and main

### DIFF
--- a/examples/import-meta-glob-test/index.html
+++ b/examples/import-meta-glob-test/index.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>nodepod — import.meta Node parity + glob diagnosis</title>
+  <style>
+    body { font-family: ui-monospace, monospace; background: #1a1a2e; color: #e0e0e0; padding: 24px; }
+    h1 { font-size: 18px; margin-bottom: 8px; }
+    p { font-size: 13px; color: #888; margin-bottom: 16px; max-width: 90ch; }
+    #output {
+      white-space: pre-wrap; font-size: 13px; line-height: 1.5;
+      background: #0d0d1a; border: 1px solid #333; border-radius: 6px;
+      padding: 16px; min-height: 360px; max-height: 70vh; overflow-y: auto;
+    }
+    .pass { color: #a8e6a3; }
+    .fail { color: #e68a8a; font-weight: 700; }
+    .info { color: #8ac4e6; }
+    .dim { color: #666; }
+    .stdout { color: #a8e6a3; }
+    .stderr { color: #e68a8a; }
+    #status { margin-top: 12px; font-size: 14px; font-weight: 700; }
+  </style>
+</head>
+<body>
+  <h1>import.meta Node parity + glob diagnosis</h1>
+  <p>
+    1) Node <code>import.meta.resolve</code> / <code>main</code> must work (1:1 Node).<br/>
+    2) Raw <code>import()</code> of a file with <code>import.meta.glob</code> must show the
+    ScriptEngine fingerprint (<code>import_meta.glob is not a function</code>) — Vite never
+    transforms that path. Vite's expand only runs via <code>ssrLoadModule</code> / module graph.
+  </p>
+  <div id="output"></div>
+  <div id="status" class="dim">idle</div>
+
+  <script type="module">
+    const buildTag = new URL(import.meta.url).searchParams.get("build") || Date.now();
+    const { Nodepod } = await import(`/dist/index.mjs?b=${buildTag}`);
+
+    const out = document.getElementById("output");
+    const statusEl = document.getElementById("status");
+    const log = (text, cls = "stdout") => {
+      const span = document.createElement("span");
+      span.className = cls;
+      span.textContent = text + "\n";
+      out.appendChild(span);
+      out.scrollTop = out.scrollHeight;
+    };
+
+    let failed = 0;
+    const pass = (msg) => log("PASS  " + msg, "pass");
+    const fail = (msg) => { failed++; log("FAIL  " + msg, "fail"); };
+
+    async function runToCompletion(pod, command, args = []) {
+      const proc = await pod.spawn(command, args, { cwd: "/" });
+      proc.on("output", (t) => log(t.trimEnd(), "stdout"));
+      proc.on("error", (t) => log(t.trimEnd(), "stderr"));
+      return proc.completion;
+    }
+
+    const files = {
+      "/check-meta.mjs": `
+const info = {
+  url: import.meta.url,
+  filename: import.meta.filename,
+  dirname: import.meta.dirname,
+  main: import.meta.main,
+  resolveRel: import.meta.resolve("./check-meta.mjs"),
+  resolveFs: import.meta.resolve("fs"),
+};
+console.log(JSON.stringify(info));
+`,
+      "/server/api/hello.ts": `export default function hello() { return { ok: true }; }\n`,
+      "/server/api/ping.ts": `export default function ping() { return { pong: true }; }\n`,
+      "/server/register-api.ts": `
+const modules = import.meta.glob("./api/**/*.ts", { eager: true });
+export function listApis() {
+  return Object.keys(modules).sort();
+}
+`,
+      "/probe-raw-glob.mjs": `
+try {
+  await import("./server/register-api.ts");
+  console.log(JSON.stringify({ ok: true }));
+} catch (e) {
+  console.log(JSON.stringify({
+    ok: false,
+    message: e?.message || String(e),
+    name: e?.name || "Error",
+  }));
+}
+`,
+    };
+
+    try {
+      log("Booting nodepod...", "info");
+      const nodepod = await Nodepod.boot({
+        workdir: "/",
+        enableSnapshotCache: false,
+        files,
+      });
+      pass("Nodepod.boot");
+
+      log("\n--- Node import.meta parity ---", "info");
+      {
+        const res = await runToCompletion(nodepod, "node", ["check-meta.mjs"]);
+        const line = (res.stdout || "").trim().split("\n").filter(Boolean).pop() || "";
+        try {
+          const info = JSON.parse(line);
+          if (info.main === true) pass("import.meta.main === true on entry");
+          else fail("import.meta.main expected true, got " + JSON.stringify(info.main));
+
+          if (typeof info.resolveRel === "string" && info.resolveRel.startsWith("file://") && info.resolveRel.endsWith("check-meta.mjs"))
+            pass("import.meta.resolve('./check-meta.mjs') => " + info.resolveRel);
+          else fail("import.meta.resolve relative bad: " + info.resolveRel);
+
+          if (info.resolveFs === "node:fs") pass("import.meta.resolve('fs') => node:fs");
+          else fail("import.meta.resolve('fs') => " + info.resolveFs);
+
+          if (typeof info.filename === "string" && info.filename.endsWith("check-meta.mjs"))
+            pass("import.meta.filename ok");
+          else fail("import.meta.filename bad: " + info.filename);
+        } catch (e) {
+          fail("check-meta parse failed: " + (e?.message || e) + " stdout=" + JSON.stringify(res.stdout));
+        }
+      }
+
+      log("\n--- Raw import() of import.meta.glob (no Vite transform) ---", "info");
+      {
+        const res = await runToCompletion(nodepod, "node", ["probe-raw-glob.mjs"]);
+        const line = (res.stdout || "").trim().split("\n").filter(Boolean).pop() || "";
+        try {
+          const info = JSON.parse(line);
+          if (info.ok) {
+            fail("raw import unexpectedly succeeded — glob should not run without Vite transform");
+          } else if (String(info.message).includes("import_meta.glob is not a function")) {
+            pass("raw import hit ScriptEngine fingerprint: " + info.message);
+            log("  diagnosis: import() => __asyncLoad => loadModule rewrites import.meta → import_meta;", "info");
+            log("  Vite's vite:import-glob never saw the file. Use server.ssrLoadModule() for glob.", "info");
+          } else if (String(info.message).includes("import.meta.glob is not a function")) {
+            pass("raw import failed (Node-shaped): " + info.message);
+          } else {
+            fail("raw import failed with unexpected error: " + info.message);
+          }
+        } catch (e) {
+          fail("probe-raw-glob parse failed: " + (e?.message || e) + " stdout=" + JSON.stringify(res.stdout));
+        }
+      }
+
+      try { nodepod.teardown(); } catch {}
+    } catch (e) {
+      fail("top-level: " + (e?.stack || e?.message || e));
+    }
+
+    if (failed === 0) {
+      statusEl.textContent = "ALL PASSED";
+      statusEl.className = "pass";
+      log("\nALL PASSED", "pass");
+    } else {
+      statusEl.textContent = "FAIL (" + failed + ")";
+      statusEl.className = "fail";
+      log("\nFAILED: " + failed, "fail");
+    }
+    window.__globTestDone = { ok: failed === 0, failed };
+  </script>
+</body>
+</html>

--- a/examples/import-meta-glob-test/run.mjs
+++ b/examples/import-meta-glob-test/run.mjs
@@ -1,0 +1,38 @@
+// Headless runner for examples/import-meta-glob-test
+import { chromium } from "@playwright/test";
+
+const url = process.env.EXAMPLE_URL || "http://127.0.0.1:3333/examples/import-meta-glob-test/";
+const timeoutMs = Number(process.env.TEST_TIMEOUT_MS || 300_000);
+
+const browser = await chromium.launch({ headless: true });
+const page = await browser.newPage();
+
+page.on("console", (msg) => {
+  console.log(`[browser:${msg.type()}] ${msg.text()}`);
+});
+page.on("pageerror", (err) => {
+  console.log(`[pageerror] ${err.message}`);
+});
+
+console.log(`Navigating to ${url}`);
+await page.goto(url, { waitUntil: "domcontentloaded", timeout: 60_000 });
+
+console.log("Waiting for window.__globTestDone ...");
+const result = await page.waitForFunction(
+  () => window.__globTestDone || null,
+  null,
+  { timeout: timeoutMs },
+).then((h) => h.jsonValue());
+
+const status = await page.locator("#status").innerText();
+const output = await page.locator("#output").innerText();
+
+console.log("\n===== OUTPUT =====\n" + output.slice(-8000));
+console.log("\n===== STATUS =====\n" + status);
+console.log("\n===== RESULT =====\n" + JSON.stringify(result, null, 2));
+
+await browser.close();
+
+if (!result?.ok) {
+  process.exit(1);
+}

--- a/examples/serve.js
+++ b/examples/serve.js
@@ -65,6 +65,7 @@ createServer((req, res) => {
   console.log(`  Vite dev exit 1:      http://localhost:${port}/examples/vite-dev-exit-1/  (auth+sqlite repro)`);
   console.log(`  Scelar auth template: http://localhost:${port}/examples/scelar-auth-template/`);
   console.log(`  Scelar Vite repro:    http://localhost:${port}/examples/scelar-vite-config-repro/`);
+  console.log(`  import.meta.glob:     http://localhost:${port}/examples/import-meta-glob-test/`);
   console.log(`  Terminal + preview:   http://localhost:${port}/examples/terminal/`);
   console.log(`  Preview inspector:     http://localhost:${port}/examples/preview-inspector/`);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scelar/nodepod",
-  "version": "1.9.12",
+  "version": "1.9.13",
   "description": "Browser-native Node.js runtime environment",
   "type": "module",
   "license": "MIT WITH Commons-Clause",

--- a/src/__tests__/import-meta.test.ts
+++ b/src/__tests__/import-meta.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect } from "vitest";
+import { createImportMeta } from "../helpers/import-meta";
+import { MemoryVolume } from "../memory-volume";
+import { ScriptEngine } from "../script-engine";
+import { isBuiltin } from "../polyfills/module";
+
+describe("createImportMeta", () => {
+  it("exposes url/filename/dirname/main", () => {
+    const meta = createImportMeta({
+      filename: "/app/entry.mjs",
+      dirname: "/app",
+      isMain: true,
+      isBuiltin,
+      resolvePath: (spec, from) => {
+        if (spec === "./x.mjs") return `${from}/x.mjs`;
+        throw Object.assign(new Error("not found"), { code: "MODULE_NOT_FOUND" });
+      },
+    });
+    expect(meta.url).toBe("file:///app/entry.mjs");
+    expect(meta.filename).toBe("/app/entry.mjs");
+    expect(meta.dirname).toBe("/app");
+    expect(meta.main).toBe(true);
+  });
+
+  it("resolve() returns file URLs for relative specifiers", () => {
+    const meta = createImportMeta({
+      filename: "/app/entry.mjs",
+      dirname: "/app",
+      isMain: true,
+      isBuiltin,
+      resolvePath: (spec, from) => `${from}/${spec.replace(/^\.\//, "")}`,
+    });
+    expect(meta.resolve("./x.mjs")).toBe("file:///app/x.mjs");
+  });
+
+  it("resolve() returns node: URLs for builtins", () => {
+    const meta = createImportMeta({
+      filename: "/app/entry.mjs",
+      dirname: "/app",
+      isMain: false,
+      isBuiltin,
+      resolvePath: (spec) => spec.replace(/^node:/, ""),
+    });
+    expect(meta.resolve("fs")).toBe("node:fs");
+    expect(meta.resolve("node:path")).toBe("node:path");
+  });
+
+  it("resolve() honors parentURL", () => {
+    const meta = createImportMeta({
+      filename: "/app/entry.mjs",
+      dirname: "/app",
+      isMain: true,
+      isBuiltin,
+      resolvePath: (spec, from) => `${from}/${spec.replace(/^\.\//, "")}`,
+    });
+    expect(meta.resolve("./y.mjs", "file:///other/dir/mod.mjs")).toBe(
+      "file:///other/dir/y.mjs",
+    );
+  });
+});
+
+describe("ScriptEngine import.meta", () => {
+  function boot(files: Record<string, string>) {
+    const vol = new MemoryVolume();
+    for (const [path, src] of Object.entries(files)) {
+      const dir = path.slice(0, path.lastIndexOf("/")) || "/";
+      if (dir !== "/") vol.mkdirSync(dir, { recursive: true });
+      vol.writeFileSync(path, src);
+    }
+    return new ScriptEngine(vol, { cwd: "/" });
+  }
+
+  it("entry module has import.meta.main === true", async () => {
+    const eng = boot({
+      "/entry.mjs": `
+        export const isMain = import.meta.main;
+        export const url = import.meta.url;
+        export const filename = import.meta.filename;
+        export const dirname = import.meta.dirname;
+      `,
+    });
+    const { exports } = await eng.runFileTLA("/entry.mjs");
+    const mod = exports as {
+      isMain: boolean;
+      url: string;
+      filename: string;
+      dirname: string;
+    };
+    expect(mod.isMain).toBe(true);
+    expect(mod.url).toBe("file:///entry.mjs");
+    expect(mod.filename).toBe("/entry.mjs");
+    expect(mod.dirname).toBe("/");
+  });
+
+  it("dependency module has import.meta.main === false", async () => {
+    const eng = boot({
+      "/entry.mjs": `
+        import { isMain as depMain } from "./dep.mjs";
+        export const entryMain = import.meta.main;
+        export { depMain };
+      `,
+      "/dep.mjs": `
+        export const isMain = import.meta.main;
+      `,
+    });
+    const { exports } = await eng.runFileTLA("/entry.mjs");
+    const mod = exports as { entryMain: boolean; depMain: boolean };
+    expect(mod.entryMain).toBe(true);
+    expect(mod.depMain).toBe(false);
+  });
+
+  it("import.meta.resolve resolves relatives and builtins", async () => {
+    const eng = boot({
+      "/app/entry.mjs": `
+        export const rel = import.meta.resolve("./sibling.mjs");
+        export const builtin = import.meta.resolve("fs");
+        export const nodeBuiltin = import.meta.resolve("node:path");
+      `,
+      "/app/sibling.mjs": `export default 1;`,
+    });
+    const { exports } = await eng.runFileTLA("/app/entry.mjs");
+    const mod = exports as {
+      rel: string;
+      builtin: string;
+      nodeBuiltin: string;
+    };
+    expect(mod.rel).toBe("file:///app/sibling.mjs");
+    expect(mod.builtin).toBe("node:fs");
+    expect(mod.nodeBuiltin).toBe("node:path");
+  });
+
+  it("regex fallback does not rewrite import.meta inside string literals", async () => {
+    // Force a source that mentions the guard string Vite uses, plus a real
+    // import.meta.url read. AST path preserves strings; this asserts the
+    // runtime still sees the literal text either way.
+    const eng = boot({
+      "/guard.mjs": `
+        export const guard = 'import.meta.glob';
+        export const url = import.meta.url;
+        export const hasGlobText = guard.includes('import.meta.glob');
+      `,
+    });
+    const { exports } = await eng.runFileTLA("/guard.mjs");
+    const mod = exports as {
+      guard: string;
+      url: string;
+      hasGlobText: boolean;
+    };
+    expect(mod.guard).toBe("import.meta.glob");
+    expect(mod.hasGlobText).toBe(true);
+    expect(mod.url).toBe("file:///guard.mjs");
+  });
+
+  it("raw import of import.meta.glob fails with ScriptEngine fingerprint", async () => {
+    const eng = boot({
+      "/server/api/hello.ts": `export default function hello() { return 1; }`,
+      "/server/register-api.ts": `
+        const modules = import.meta.glob("./api/**/*.ts", { eager: true });
+        export function listApis() { return Object.keys(modules); }
+      `,
+      "/probe.mjs": `
+        try {
+          await import("./server/register-api.ts");
+          export const ok = true;
+        } catch (e) {
+          export const ok = false;
+          export const message = e instanceof Error ? e.message : String(e);
+        }
+      `,
+    });
+    // Top-level try/catch with export inside is awkward after transform; run the
+    // register-api file directly instead.
+    await expect(eng.runFileTLA("/server/register-api.ts")).rejects.toThrow(
+      /import_meta\.glob is not a function/,
+    );
+  });
+});
+
+describe("Vite import.meta.glob transform (host Node)", () => {
+  it("ssr transform expands import.meta.glob before evaluation", async () => {
+    const { mkdtemp, writeFile, mkdir, rm } = await import("node:fs/promises");
+    const { join } = await import("node:path");
+    const { tmpdir } = await import("node:os");
+    const { createServer } = await import("vite");
+
+    const dir = await mkdtemp(join(tmpdir(), "nodepod-glob-"));
+    try {
+      await mkdir(join(dir, "server", "api"), { recursive: true });
+      await writeFile(
+        join(dir, "server", "api", "hello.ts"),
+        `export default function hello() { return 1; }\n`,
+      );
+      await writeFile(
+        join(dir, "server", "register-api.ts"),
+        `
+const modules = import.meta.glob("./api/**/*.ts", { eager: true });
+export function listApis() { return Object.keys(modules).sort(); }
+`,
+      );
+
+      const server = await createServer({
+        configFile: false,
+        root: dir,
+        server: { middlewareMode: true },
+        appType: "custom",
+        logLevel: "silent",
+      });
+
+      const tr = await server.transformRequest("/server/register-api.ts", {
+        ssr: true,
+      });
+      expect(tr?.code).toBeTruthy();
+      expect(tr!.code).not.toMatch(/import\.meta\.glob\s*\(/);
+      expect(tr!.code).toMatch(/hello\.ts/);
+
+      const mod = await server.ssrLoadModule("/server/register-api.ts");
+      expect(mod.listApis()).toEqual(["./api/hello.ts"]);
+
+      await server.close();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/helpers/import-meta.ts
+++ b/src/helpers/import-meta.ts
@@ -1,0 +1,107 @@
+// Node-compatible import.meta object for ScriptEngine module wrappers.
+// Mirrors Node's host-defined import.meta fields (url/filename/dirname/resolve/main).
+// Vite-only APIs (glob/env/hot) are intentionally absent — those are compile-time.
+
+import { pathToFileURL, fileURLToPath } from "../polyfills/url";
+import * as pathPolyfill from "../polyfills/path";
+
+export interface NodeImportMeta {
+  url: string;
+  filename: string;
+  dirname: string;
+  /** true when this module is the process entry point (Node >= 24.2 / 22.18). */
+  main: boolean;
+  /** Resolve a specifier to a URL string relative to this module (or parent). */
+  resolve: (specifier: string, parent?: string | URL) => string;
+}
+
+export interface CreateImportMetaOptions {
+  filename: string;
+  dirname: string;
+  /** Resolve a specifier to an absolute filesystem path (or bare builtin id). */
+  resolvePath: (specifier: string, fromDir: string) => string;
+  isMain: boolean;
+  /** Return true when `id` is a node builtin (with or without node: prefix). */
+  isBuiltin?: (id: string) => boolean;
+}
+
+function toFileUrlString(fsPath: string): string {
+  if (fsPath.startsWith("file://")) return fsPath;
+  return pathToFileURL(fsPath).href;
+}
+
+function parentToDir(parent: string | URL, fallbackDir: string): string {
+  try {
+    const href = typeof parent === "string" ? parent : parent.href;
+    if (href.startsWith("file:")) {
+      return pathPolyfill.dirname(fileURLToPath(href));
+    }
+    // non-file parents: best-effort path-like
+    if (href.startsWith("/")) return pathPolyfill.dirname(href);
+  } catch {
+    /* fall through */
+  }
+  return fallbackDir;
+}
+
+/**
+ * Build the import.meta object injected as $importMeta into every module wrapper.
+ */
+export function createImportMeta(opts: CreateImportMetaOptions): NodeImportMeta {
+  const filename = opts.filename;
+  const dirname = opts.dirname;
+  const metaUrl = toFileUrlString(filename);
+  const isBuiltin = opts.isBuiltin ?? (() => false);
+
+  const resolve = (specifier: string, parent?: string | URL): string => {
+    if (typeof specifier !== "string") {
+      const err: any = new TypeError(
+        `The "specifier" argument must be of type string. Received type ${typeof specifier}`,
+      );
+      err.code = "ERR_INVALID_ARG_TYPE";
+      throw err;
+    }
+
+    // Bare builtins resolve to node: URLs, matching Node.
+    const bare = specifier.startsWith("node:") ? specifier.slice(5) : specifier;
+    if (isBuiltin(specifier) || isBuiltin(bare)) {
+      return specifier.startsWith("node:") ? specifier : `node:${specifier}`;
+    }
+
+    const fromDir =
+      parent !== undefined ? parentToDir(parent, dirname) : dirname;
+
+    try {
+      const resolved = opts.resolvePath(specifier, fromDir);
+      if (typeof resolved !== "string" || resolved.length === 0) {
+        const err: any = new Error(
+          `Cannot find module '${specifier}' imported from ${filename}`,
+        );
+        err.code = "ERR_MODULE_NOT_FOUND";
+        throw err;
+      }
+      // Resolver may return bare builtin ids for node: lookups
+      if (isBuiltin(resolved) || resolved.startsWith("node:")) {
+        return resolved.startsWith("node:") ? resolved : `node:${resolved}`;
+      }
+      return toFileUrlString(resolved);
+    } catch (e: any) {
+      if (e?.code === "ERR_MODULE_NOT_FOUND" || e?.code === "MODULE_NOT_FOUND") {
+        const err: any = new Error(
+          `Cannot find module '${specifier}' imported from ${filename}`,
+        );
+        err.code = "ERR_MODULE_NOT_FOUND";
+        throw err;
+      }
+      throw e;
+    }
+  };
+
+  return {
+    url: metaUrl,
+    filename,
+    dirname,
+    main: opts.isMain,
+    resolve,
+  };
+}

--- a/src/script-engine.ts
+++ b/src/script-engine.ts
@@ -1997,7 +1997,9 @@ function buildResolver(
     return record;
   };
 
-  const resolver: ResolverFn = (id: string): unknown => {
+  // Typed as ResolverFn only after resolve/cache/extensions/main are attached
+  // below — defineProperty(main) is invisible to the checker at declaration.
+  const resolver = ((id: string): unknown => {
     if (typeof id !== "string") {
       // Match real Node.js error: TypeError with ERR_INVALID_ARG_TYPE code
       const err: any = new TypeError(
@@ -2270,7 +2272,7 @@ function buildResolver(
       });
     }
     return rec.exports;
-  };
+  }) as ResolverFn;
 
   resolver.resolve = (id: string, options?: { paths?: string[] }): string => {
     if (id === "fs" || id === "process" || CORE_MODULES[id]) return id;

--- a/src/script-engine.ts
+++ b/src/script-engine.ts
@@ -10,6 +10,7 @@ import type {
 } from "./engine-types";
 import type { PackageManifest } from "./types/manifest";
 import { quickDigest } from "./helpers/digest";
+import { createImportMeta } from "./helpers/import-meta";
 import { LRUCache as _LRUCache } from "./memory-handler";
 import { bytesToBase64, bytesToHex } from "./helpers/byte-encoding";
 import { buildFileSystemBridge, FsBridge } from "./polyfills/fs";
@@ -515,18 +516,136 @@ ${code}
 })`;
 }
 
+/**
+ * Replace import.meta references without touching string/template/comment
+ * contents. The naive /\bimport\.meta\b/g fallback corrupts Vite's own
+ * guards like code.includes("import.meta.glob"), which then skips the
+ * compile-time glob expand and leaves a runtime .glob() call.
+ */
+function replaceImportMetaOutsideLiterals(
+  source: string,
+  replace: (matched: string) => string,
+): string {
+  let out = "";
+  let i = 0;
+  const len = source.length;
+  while (i < len) {
+    const ch = source[i];
+    const next = i + 1 < len ? source[i + 1] : "";
+
+    // line comment
+    if (ch === "/" && next === "/") {
+      const end = source.indexOf("\n", i);
+      const stop = end === -1 ? len : end;
+      out += source.slice(i, stop);
+      i = stop;
+      continue;
+    }
+    // block comment
+    if (ch === "/" && next === "*") {
+      const end = source.indexOf("*/", i + 2);
+      const stop = end === -1 ? len : end + 2;
+      out += source.slice(i, stop);
+      i = stop;
+      continue;
+    }
+    // string / template literal
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      let j = i + 1;
+      while (j < len) {
+        if (source[j] === "\\") {
+          j += 2;
+          continue;
+        }
+        if (source[j] === quote) {
+          j++;
+          break;
+        }
+        // template: skip ${ ... } with naive depth so nested braces in
+        // expressions don't truncate the literal early
+        if (quote === "`" && source[j] === "$" && source[j + 1] === "{") {
+          j += 2;
+          let depth = 1;
+          while (j < len && depth > 0) {
+            if (source[j] === "\\") {
+              j += 2;
+              continue;
+            }
+            if (source[j] === '"' || source[j] === "'") {
+              const q = source[j++];
+              while (j < len) {
+                if (source[j] === "\\") {
+                  j += 2;
+                  continue;
+                }
+                if (source[j] === q) {
+                  j++;
+                  break;
+                }
+                j++;
+              }
+              continue;
+            }
+            if (source[j] === "{") depth++;
+            else if (source[j] === "}") depth--;
+            j++;
+          }
+          continue;
+        }
+        j++;
+      }
+      out += source.slice(i, j);
+      i = j;
+      continue;
+    }
+
+    if (
+      ch === "i" &&
+      source.startsWith("import.meta", i) &&
+      (i === 0 || !/[\w$]/.test(source[i - 1]!))
+    ) {
+      const after = i + "import.meta".length;
+      if (after >= len || !/[\w$]/.test(source[after]!)) {
+        // longest suffix first
+        if (source.startsWith("import.meta.filename", i)) {
+          out += replace("import.meta.filename");
+          i += "import.meta.filename".length;
+          continue;
+        }
+        if (source.startsWith("import.meta.dirname", i)) {
+          out += replace("import.meta.dirname");
+          i += "import.meta.dirname".length;
+          continue;
+        }
+        if (source.startsWith("import.meta.url", i)) {
+          out += replace("import.meta.url");
+          i += "import.meta.url".length;
+          continue;
+        }
+        out += replace("import.meta");
+        i += "import.meta".length;
+        continue;
+      }
+    }
+
+    out += ch;
+    i++;
+  }
+  return out;
+}
+
 function convertViaRegex(source: string, filePath: string): string {
   let output = source;
-  output = output.replace(/\bimport\.meta\.url\b/g, `"file://${filePath}"`);
-  output = output.replace(
-    /\bimport\.meta\.dirname\b/g,
-    `"${pathPolyfill.dirname(filePath)}"`,
-  );
-  output = output.replace(/\bimport\.meta\.filename\b/g, `"${filePath}"`);
-  output = output.replace(
-    /\bimport\.meta\b/g,
-    `({ url: "file://${filePath}", dirname: "${pathPolyfill.dirname(filePath)}", filename: "${filePath}" })`,
-  );
+  const dir = pathPolyfill.dirname(filePath);
+  output = replaceImportMetaOutsideLiterals(output, (matched) => {
+    if (matched === "import.meta.url") return `"file://${filePath}"`;
+    if (matched === "import.meta.dirname") return `"${dir}"`;
+    if (matched === "import.meta.filename") return `"${filePath}"`;
+    // Keep the identifier form so the module wrapper's $importMeta binding
+    // (url/dirname/filename/resolve/main) is what user code sees — same as AST.
+    return "import_meta";
+  });
   output = rewriteDynamicImportsRegex(output);
 
   const hasImport = /\bimport\s+[\w{*'"]/m.test(source);
@@ -979,6 +1098,22 @@ export interface ResolverFn {
   extensions: Record<string, unknown>;
   main: ModuleRecord | null;
   _ownerRecord?: ModuleRecord;
+}
+
+/** Build the Node-compatible import.meta object for a module under `resolver`. */
+function importMetaForModule(
+  resolver: ResolverFn,
+  filename: string,
+  dirname: string,
+) {
+  return createImportMeta({
+    filename,
+    dirname,
+    isMain: resolver.main != null && resolver.main.filename === filename,
+    isBuiltin: moduleSysPolyfill.isBuiltin,
+    resolvePath: (specifier, fromDir) =>
+      resolver.resolve(specifier, { paths: [fromDir] }),
+  });
 }
 
 // Mutable copy so packages can monkey-patch frozen polyfill namespaces
@@ -1699,11 +1834,8 @@ function buildResolver(
               node.meta?.name === "import" &&
               node.property?.name === "meta"
             ) {
-              cjsPatches.push([
-                node.start,
-                node.end,
-                `({ url: "file://${resolved}", dirname: "${pathPolyfill.dirname(resolved)}", filename: "${resolved}" })`,
-              ]);
+              // Use the wrapper's $importMeta binding (resolve/main included)
+              cjsPatches.push([node.start, node.end, "import_meta"]);
             }
             for (const key of Object.keys(node)) {
               if (key === "type" || key === "start" || key === "end") continue;
@@ -1760,7 +1892,6 @@ function buildResolver(
     const wrappedConsole = wrapConsole(opts.onConsole);
 
     try {
-      const metaUrl = "file://" + resolved;
       const wrapper = buildModuleWrapper(processedCode);
 
       let fn;
@@ -1788,7 +1919,7 @@ function buildResolver(
         dir,
         proc,
         wrappedConsole,
-        { url: metaUrl, dirname: dir, filename: resolved },
+        importMetaForModule(childResolver, resolved, dir),
         asyncLoader,
         syncAwait,
         SyncPromiseClass,
@@ -1837,7 +1968,7 @@ function buildResolver(
             dir,
             proc,
             wrappedConsole,
-            { url: "file://" + resolved, dirname: dir, filename: resolved },
+            importMetaForModule(childResolver, resolved, dir),
             asyncLoader,
             syncAwait,
             SyncPromiseClass,
@@ -2165,8 +2296,21 @@ function buildResolver(
     ".mjs": () => {},
     ".cjs": () => {},
   };
-  resolver.main = null;
+  // Share the process entry module across child resolvers (require.main /
+  // import.meta.main). Set via markResolverMain() from execute/runFileTLA.
+  Object.defineProperty(resolver, "main", {
+    configurable: true,
+    enumerable: true,
+    get: () => ((cache as any).__mainModule as ModuleRecord | null) ?? null,
+    set: (mod: ModuleRecord | null) => {
+      (cache as any).__mainModule = mod;
+    },
+  });
   return resolver;
+}
+
+function markResolverMain(resolver: ResolverFn, mod: ModuleRecord): void {
+  if (resolver.main == null) resolver.main = mod;
 }
 
 // ── ScriptEngine class ──
@@ -2758,11 +2902,7 @@ export class ScriptEngine {
             node.meta?.name === "import" &&
             node.property?.name === "meta"
           ) {
-            cjsPatches.push([
-              node.start,
-              node.end,
-              `({ url: "file://${filename}", dirname: "${pathPolyfill.dirname(filename)}", filename: "${filename}" })`,
-            ]);
+            cjsPatches.push([node.start, node.end, "import_meta"]);
           }
           for (const key of Object.keys(node)) {
             if (key === "type" || key === "start" || key === "end") continue;
@@ -2801,9 +2941,9 @@ export class ScriptEngine {
       fileHasTLA,
     );
     resolver._ownerRecord = mod;
+    markResolverMain(resolver, mod);
 
     try {
-      const metaUrl = "file://" + filename;
       const wrapper = buildModuleWrapper(processed);
 
       const asyncLoader = makeDynamicLoader(resolver);
@@ -2822,7 +2962,7 @@ export class ScriptEngine {
         dir,
         this.proc,
         consoleProxy,
-        { url: metaUrl, dirname: dir, filename },
+        importMetaForModule(resolver, filename, dir),
         asyncLoader,
         syncAwait,
         SyncPromiseClass,
@@ -2884,14 +3024,7 @@ export class ScriptEngine {
     let tla = false;
     if (filename.endsWith(".cjs")) {
       processed = rewriteDynamicImportsRegex(processed);
-      processed = processed.replace(
-        /\bimport\.meta\.url\b/g,
-        `"file://${filename}"`,
-      );
-      processed = processed.replace(
-        /\bimport\.meta\b/g,
-        `({ url: "file://${filename}" })`,
-      );
+      processed = replaceImportMetaOutsideLiterals(processed, () => "import_meta");
     } else {
       const converted = convertModuleSyntaxDetailed(processed, filename);
       processed = converted.code;
@@ -2912,6 +3045,7 @@ export class ScriptEngine {
       false,
     );
     resolver._ownerRecord = mod;
+    markResolverMain(resolver, mod);
 
     if (!tla) {
       try {
@@ -2928,7 +3062,7 @@ export class ScriptEngine {
           dir,
           this.proc,
           consoleProxy,
-          { url: "file://" + filename, dirname: dir, filename },
+          importMetaForModule(resolver, filename, dir),
           asyncLoader,
           syncAwait,
           SyncPromiseClass,
@@ -2942,7 +3076,6 @@ export class ScriptEngine {
     }
 
     try {
-      const metaUrl = "file://" + filename;
       const wrapper = buildModuleWrapper(processed, { async: true });
       const asyncLoader = makeDynamicLoader(resolver);
       const fn = (0, eval)(wrapper);
@@ -2954,7 +3087,7 @@ export class ScriptEngine {
         dir,
         this.proc,
         consoleProxy,
-        { url: metaUrl, dirname: dir, filename },
+        importMetaForModule(resolver, filename, dir),
         asyncLoader,
         syncAwait,
         SyncPromiseClass,
@@ -2978,6 +3111,7 @@ export class ScriptEngine {
     (this.moduleRegistry as any).__resolveCache?.clear();
     (this.moduleRegistry as any).__manifestCache?.clear();
     delete (this.moduleRegistry as any).__pkgIdentityMap;
+    delete (this.moduleRegistry as any).__mainModule;
     this.transformCache.clear();
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Node-shaped `import.meta.resolve()` and `import.meta.main` to ScriptEngine’s `$importMeta` shim (no Vite-specific `glob`/`hot`/`env` APIs). Also keeps the regex `import.meta` rewrite out of string/comment literals so Vite’s `code.includes("import.meta.glob")` guards stay intact.

## Why

Running Vite apps that use `import.meta.glob` via raw `import()` inside nodepod fails with `import_meta.glob is not a function` because that path never hits Vite’s transform. Separately, the shim was missing real Node fields (`resolve`, `main`).

This PR only closes the Node parity gap and hardens the rewrite. App code that needs Vite glob still must go through `server.ssrLoadModule()` / the Vite module graph.

## Test plan

- [x] `pnpm exec vitest run src/__tests__/import-meta.test.ts` (10 tests)
- [x] Browser example `examples/import-meta-glob-test/` via Playwright (`node examples/import-meta-glob-test/run.mjs`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c5fb041-0124-4bb3-9ce4-cb6a3b8d6057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c5fb041-0124-4bb3-9ce4-cb6a3b8d6057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

