### PR TITLE
fix: Expo Metro web — honor listen(port, undefined, cb)

### DIFF
--- a/src/__tests__/http-listen-callback.test.ts
+++ b/src/__tests__/http-listen-callback.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { createServer } from "../polyfills/http";
+
+describe("http.Server.listen callback arity", () => {
+  it("invokes callback for listen(port, cb)", async () => {
+    const server = createServer((_req, res) => {
+      res.statusCode = 200;
+      res.end("ok");
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, () => resolve());
+    });
+    expect(server.listening).toBe(true);
+    server.close();
+  });
+
+  it("invokes callback for listen(port, undefined, cb) — Expo/Metro shape", async () => {
+    const server = createServer((_req, res) => {
+      res.statusCode = 200;
+      res.end("ok");
+    });
+    let called = false;
+    await new Promise<void>((resolve, reject) => {
+      const t = setTimeout(
+        () => reject(new Error("listen callback was never invoked")),
+        2000,
+      );
+      server.listen(0, undefined as unknown as string, () => {
+        called = true;
+        clearTimeout(t);
+        resolve();
+      });
+    });
+    expect(called).toBe(true);
+    expect(server.listening).toBe(true);
+    server.close();
+  });
+
+  it("invokes callback for listen(port, host, cb)", async () => {
+    const server = createServer((_req, res) => {
+      res.statusCode = 200;
+      res.end("ok");
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    expect(server.listening).toBe(true);
+    server.close();
+  });
+});

--- a/src/__tests__/ws-server-parity.test.ts
+++ b/src/__tests__/ws-server-parity.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { ScriptEngine } from "../script-engine";
+import { MemoryVolume } from "../memory-volume";
+
+describe("ws polyfill Server parity", () => {
+  it("exposes Server on default export like the npm ws package", () => {
+    const vol = new MemoryVolume();
+    vol.mkdirSync("/project", { recursive: true });
+    const engine = new ScriptEngine(vol, { cwd: "/project" });
+    const r = engine.execute(
+      `
+      const ws = require("ws");
+      function _interop_require_default(obj) {
+        return obj && obj.__esModule ? obj : { default: obj };
+      }
+      const _ws = _interop_require_default(require("ws"));
+      const Server = _ws.default.Server;
+      const wss = new Server({ noServer: true });
+      module.exports = {
+        hasServer: typeof ws.Server === "function",
+        defaultServer: typeof Server === "function",
+        handleUpgrade: typeof wss.handleUpgrade === "function",
+        keys: Object.keys(ws),
+        esModule: !!ws.__esModule,
+      };
+      `,
+      "/project/probe.js",
+    );
+    expect(r.exports).toMatchObject({
+      hasServer: true,
+      defaultServer: true,
+      handleUpgrade: true,
+    });
+  });
+});

--- a/src/polyfills/http.ts
+++ b/src/polyfills/http.ts
@@ -535,7 +535,8 @@ Object.setPrototypeOf(Server.prototype, EventEmitter.prototype);
 
 Server.prototype.listen = function listen(
   portOrOpts?: number | { port?: number; host?: string },
-  hostOrCb?: string | (() => void),
+  hostOrCb?: string | number | (() => void) | null,
+  backlogOrCb?: number | (() => void),
   cb?: () => void,
 ): any {
   let port: number | undefined;
@@ -544,14 +545,44 @@ Server.prototype.listen = function listen(
 
   if (typeof portOrOpts === "number") {
     port = portOrOpts;
-    if (typeof hostOrCb === "string") {
+    // Node parity: listen(port, host, backlog, cb) with optional holes.
+    // Expo/Metro call listen(port, undefined, callback) — the previous
+    // implementation treated undefined host as "no callback" and dropped cb,
+    // so runServer's Promise never resolved and Expo HTML middleware never
+    // attached (GET / → Cannot GET /).
+    if (typeof hostOrCb === "function") {
+      done = hostOrCb;
+    } else if (typeof hostOrCb === "string") {
       host = hostOrCb;
-      done = cb;
-    } else done = hostOrCb;
+      if (typeof backlogOrCb === "function") {
+        done = backlogOrCb;
+      } else if (typeof backlogOrCb === "number") {
+        done = typeof cb === "function" ? cb : undefined;
+      } else {
+        done = typeof cb === "function" ? cb : undefined;
+      }
+    } else if (typeof hostOrCb === "number") {
+      // listen(port, backlog, cb)
+      done = typeof backlogOrCb === "function" ? backlogOrCb : undefined;
+    } else {
+      // host omitted/undefined/null — callback may be 3rd or 4th arg
+      if (typeof backlogOrCb === "function") {
+        done = backlogOrCb;
+      } else if (typeof cb === "function") {
+        done = cb;
+      }
+    }
   } else if (portOrOpts) {
     port = portOrOpts.port;
     host = portOrOpts.host;
-    done = typeof hostOrCb === "function" ? hostOrCb : cb;
+    done =
+      typeof hostOrCb === "function"
+        ? hostOrCb
+        : typeof backlogOrCb === "function"
+          ? backlogOrCb
+          : typeof cb === "function"
+            ? cb
+            : undefined;
   }
 
   const self = this;

--- a/src/polyfills/ws.ts
+++ b/src/polyfills/ws.ts
@@ -153,6 +153,10 @@ interface WebSocketConstructor {
   readonly OPEN: number;
   readonly CLOSING: number;
   readonly CLOSED: number;
+  /** Node `ws` package attaches Server on the default export. */
+  Server: any;
+  WebSocket: any;
+  createWebSocketStream: (...args: never[]) => never;
 }
 
 export const WebSocket = function WebSocket(this: any, address: string, protocols?: string | string[]) {
@@ -714,5 +718,13 @@ export const Server = WebSocketServer;
 export const createWebSocketStream = (): never => {
   throw new Error('createWebSocketStream is not available in the browser');
 };
+
+// Match the real `ws` package: default export is WebSocket, with Server (and
+// helpers) hung off it. Expo/Metro do `require("ws").default.Server` /
+// `new (require("ws"))().Server` via interop — without this, Metro's listen
+// callback throws after onReady and never attaches Expo HTML middleware.
+(WebSocket as WebSocketConstructor).Server = WebSocketServer;
+(WebSocket as WebSocketConstructor).WebSocket = WebSocket as WebSocketConstructor;
+(WebSocket as WebSocketConstructor).createWebSocketStream = createWebSocketStream;
 
 export default WebSocket;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fix `http.Server.listen` so `listen(port, undefined, callback)` (Expo/Metro’s shape) actually invokes the callback. Previously the callback was dropped, so Expo’s `runServer` Promise never resolved, Manifest/HTML middleware never attached (`Cannot GET /`), and AppEntry bundle requests failed against a half-started packager (surfaced as a misleading `metro` TDZ InternalError).
- Attach `WebSocket.Server` on the `ws` default export to match the npm `ws` package API used when creating Metro’s HMR websocket server.
- Add regression tests for listen arity and `ws.Server` parity.

## Test plan
- [x] `pnpm exec vitest run src/__tests__/http-listen-callback.test.ts src/__tests__/ws-server-parity.test.ts src/__tests__/issue-56-typebox-tdz-repro.test.ts`
- [x] Headless Expo SDK 54 smoke: `/status` 200, `/` 200 HTML, `AppEntry.bundle?platform=web` 200 JS (~1.3MB)
- [ ] Optional: `pnpm run build:publish && node examples/serve.js` → `/examples/expo-web-smoke/`

## Notes
Root cause was HTTP listen arity, not an `esmToCjs` TDZ around a `metro` binding.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9fa6b670-9915-4fbb-973c-c266a8c20e64?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9fa6b670-9915-4fbb-973c-c266a8c20e64&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

