### PR TITLE
Correct Nodepod documentation examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,9 @@ their own trust boundary, resource limits, network policy, and cleanup strategy.
 - [Troubleshooting](https://r1ck404.github.io/Nodepod/docs/troubleshooting/)
 
 The documentation website is maintained in the private `website/` workspace in
-this repository. Its GitHub Pages deployment remains manual until the rendered
-site has been reviewed and explicitly approved.
+this repository. It is live at [r1ck404.github.io/Nodepod](https://r1ck404.github.io/Nodepod/).
+GitHub Pages deployment is currently manual, so updates are published after
+review.
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "bugs": {
     "url": "https://github.com/R1ck404/Nodepod/issues"
   },
-  "homepage": "https://github.com/R1ck404/Nodepod#readme",
+  "homepage": "https://r1ck404.github.io/Nodepod/",
   "keywords": [
     "node",
     "browser",

--- a/website/LAUNCH.md
+++ b/website/LAUNCH.md
@@ -1,15 +1,15 @@
 # Documentation launch checklist
 
-The website is intentionally private until the owner reviews the local production build and explicitly approves publication.
+The Nodepod documentation site is live at
+`https://r1ck404.github.io/Nodepod/`. The repository uses GitHub Pages with a
+manual `workflow_dispatch` deployment while website changes remain under
+review.
 
-Do not enable GitHub Pages or run `.github/workflows/docs-pages.yml` before that approval.
+## Current state
 
-## Before approval
-
-- Run `pnpm run docs:check` under Node.js 22.12 or newer.
-- Run `pnpm run docs:test` and review the Playwright report and production screenshots.
-- Confirm the landing page, documentation search, generated API source links, reduced terminal demo, mobile layout, light/dark modes, and reduced motion.
-- Confirm the current runtime and preview-origin changes have been committed so generated source links target the intended revision.
+- Landing page, Starlight docs, generated API reference, and reduced terminal demo are public.
+- Generated API source links are recreated during every docs build and pinned to the build revision.
+- The Sponsors profile is still pending GitHub approval. Do not publish funding metadata until it is active.
 
 ## Sponsors launch gate
 
@@ -20,12 +20,11 @@ Do not enable GitHub Pages or run `.github/workflows/docs-pages.yml` before that
 - Only then add `.github/FUNDING.yml` and the root package `funding` field.
 - Do not add an empty sponsor logo wall.
 
-## After explicit approval
+## Release checklist
 
-1. Update the root package `homepage` to `https://r1ck404.github.io/Nodepod/`.
-2. Add the verified GitHub Sponsors funding metadata.
-3. Enable GitHub Pages with GitHub Actions as its source.
-4. Manually run the Documentation Pages workflow.
-5. Verify the canonical site, docs search, API pages, terminal demo, metadata, and sponsor links.
-6. Update GitHub About to the canonical URL and describe Nodepod as source-available under MIT + Commons Clause.
-7. Follow up with an automatic deployment trigger limited to website, docs, API source, and dependency changes on `main`.
+1. Run `pnpm run docs:check` under Node.js 22.12 or newer.
+2. Run `pnpm run docs:test` and review the Playwright report and screenshots.
+3. Review the landing page, docs search, API source links, terminal demo, mobile layout, light/dark modes, and reduced motion.
+4. Manually run `.github/workflows/docs-pages.yml` from `main`.
+5. Verify the canonical site, docs search, API pages, terminal demo, metadata, and sponsor status.
+6. Enable an automatic deployment trigger only after the manual workflow is stable and the desired change paths are agreed.

--- a/website/src/content/docs/docs/concepts/compatibility.md
+++ b/website/src/content/docs/docs/concepts/compatibility.md
@@ -11,12 +11,15 @@ Nodepod targets current evergreen browsers with WebAssembly, Web Workers, module
 
 ## Shared memory
 
-Cross-origin isolation enables `SharedArrayBuffer`, synchronous child-process APIs, lean worker filesystem snapshots, and threaded WASI modules. Configure these response headers on the host page:
+Cross-origin isolation enables `SharedArrayBuffer`, synchronous child-process APIs, lean worker filesystem snapshots, and threaded WASI modules. Configure these response headers on the host page. `require-corp` is stricter; `credentialless` is often easier when third-party assets do not send CORP headers. Nodepod's preview responses use `credentialless`.
 
 ```http
 Cross-Origin-Opener-Policy: same-origin
 Cross-Origin-Embedder-Policy: require-corp
 ```
+
+You can use `Cross-Origin-Embedder-Policy: credentialless` instead when that
+better fits the host's third-party assets.
 
 Without isolation, set `enableSharedArrayBuffer: false` or let feature detection choose the reduced path. `execSync()` and `spawnSync()` throw, lean worker snapshots fall back to full snapshots, and threaded packages such as native-style bundler toolchains may refuse to load.
 

--- a/website/src/content/docs/docs/concepts/how-nodepod-works.mdx
+++ b/website/src/content/docs/docs/concepts/how-nodepod-works.mdx
@@ -75,7 +75,7 @@ Polyfills under [`src/polyfills/`](https://github.com/R1ck404/Nodepod/tree/main/
 
 The package pipeline lives under [`src/packages/`](https://github.com/R1ck404/Nodepod/tree/main/src/packages). It resolves versions and exports, downloads package archives, extracts them into the virtual filesystem, and coordinates transformations.
 
-Package content may be cached in browser storage across boots. Runtime project state still belongs to the Nodepod instance, and package fetches remain subject to CORS and the configured domain policy. Setting `allowedFetchDomains: null` broadens the network trust boundary and should be intentional.
+Package content may be cached in browser storage across boots. Runtime project state still belongs to the Nodepod instance, and package fetches remain subject to browser CORS. When you configure Nodepod's optional CORS proxy, `allowedFetchDomains` controls its destination allowlist; setting it to `null` disables that check and should be intentional.
 
 ## Processes, workers, and shared state
 

--- a/website/src/content/docs/docs/concepts/security.md
+++ b/website/src/content/docs/docs/concepts/security.md
@@ -12,7 +12,7 @@ Nodepod is **not a hardened security sandbox**. It is a runtime built on browser
 - A Nodepod process runs in browser workers, but shares the browser profile, origin policies, and resource limits of the host environment.
 - The service worker and preview bridge route virtual HTTP traffic. They must be scoped and hosted deliberately.
 - Preview origins reduce cookie and service-worker overlap with the host application, but do not make malicious code safe.
-- `allowedFetchDomains: null` permits package/runtime fetches to every domain and should be a conscious product decision.
+- `allowedFetchDomains` controls the destinations checked by Nodepod's optional CORS proxy. Passing `null` disables that allowlist. Without a configured CORS proxy, browser fetches still follow normal browser CORS and host policies.
 - Files and snapshots are client-side data. Do not seed credentials, signing keys, backend tokens, or private source that a visitor should not read.
 - User-provided code can consume CPU, memory, storage, and network capacity. Apply product-level limits and provide a termination path.
 

--- a/website/src/content/docs/docs/getting-started/first-program.md
+++ b/website/src/content/docs/docs/getting-started/first-program.md
@@ -13,7 +13,8 @@ Nodepod's browser entry requires Node 20 or newer in your build tooling.
 npm install @scelar/nodepod
 ```
 
-For pnpm or Yarn, use the equivalent add command. Nodepod is an ESM package.
+For pnpm or Yarn, use the equivalent add command. Nodepod publishes both ESM
+and CommonJS builds; the examples here use ESM syntax.
 
 ## Boot and run
 

--- a/website/src/content/docs/docs/guides/http-servers.md
+++ b/website/src/content/docs/docs/guides/http-servers.md
@@ -6,6 +6,13 @@ sidebar:
 ---
 
 ```ts
+import { Nodepod } from '@scelar/nodepod';
+
+let markServerReady: (() => void) | undefined;
+const serverReady = new Promise<void>((resolve) => {
+  markServerReady = resolve;
+});
+
 const nodepod = await Nodepod.boot({
   files: {
     '/server.js': `
@@ -15,10 +22,18 @@ const nodepod = await Nodepod.boot({
       }).listen(3000);
     `,
   },
+  onServerReady: (port) => {
+    if (port === 3000) markServerReady?.();
+  },
 });
 
 await nodepod.spawn('node', ['server.js']);
+await serverReady;
 ```
+
+`spawn()` waits for the process worker to be ready, not for an HTTP server
+inside that process to finish listening. Use `onServerReady` (as above) before
+calling `request()` or `port()`.
 
 Call the server without a service worker:
 

--- a/website/src/content/docs/docs/guides/snapshots.md
+++ b/website/src/content/docs/docs/guides/snapshots.md
@@ -6,12 +6,15 @@ sidebar:
 ---
 
 ```ts
-const snapshot = await nodepod.snapshot();
+const snapshot = nodepod.snapshot();
 
 // Store the serializable snapshot in application-controlled storage.
 
 await nodepod.restore(snapshot);
 ```
+
+`snapshot()` is synchronous. `restore()` is asynchronous because it can
+reinstall dependencies from `package.json`.
 
 Snapshots capture project filesystem state. Shallow snapshots exclude reinstallable package data by default to reduce size. Restoring can reinstall dependencies from `package.json` when that option is enabled.
 

--- a/website/src/content/docs/docs/setup/generic-server.md
+++ b/website/src/content/docs/docs/setup/generic-server.md
@@ -38,6 +38,9 @@ app.get('/__sw__.js', async (_request, response) => {
 });
 ```
 
-Route the HTML and script bridge paths in the same way with `servePreviewBridgeNode('html')` and `servePreviewBridgeNode('script')`.
+The bridge helpers return the response body and headers, so mount both paths
+using the same response-writing pattern. For the HTML bridge, forward a
+`mode=top` or `mode=parent` query when your preview host uses the top-level
+bootstrap handoff. The complete Express example is in [Preview deployment](/Nodepod/docs/setup/preview-deployment/).
 
 Only route the documented Nodepod paths to these handlers. Your application remains responsible for authentication, caching policy outside those paths, and wildcard preview-host routing.

--- a/website/src/content/docs/docs/setup/preview-deployment.md
+++ b/website/src/content/docs/docs/setup/preview-deployment.md
@@ -131,10 +131,20 @@ app.get('/__sw__.js', async (_req, res) => {
   res.status(200).send(body);
 });
 
-// Mount these the same way at /__nodepod_bridge__.html and
-// /__nodepod_bridge__.js, passing "html" or "script" respectively:
-await servePreviewBridgeNode('html');
-await servePreviewBridgeNode('script');
+app.get('/__nodepod_bridge__.html', async (req, res) => {
+  const mode = req.query.mode === 'top' || req.query.mode === 'parent'
+    ? req.query.mode
+    : null;
+  const { body, headers } = await servePreviewBridgeNode('html', mode);
+  for (const [k, v] of Object.entries(headers)) res.setHeader(k, v);
+  res.status(200).send(body);
+});
+
+app.get('/__nodepod_bridge__.js', async (_req, res) => {
+  const { body, headers } = await servePreviewBridgeNode('script');
+  for (const [k, v] of Object.entries(headers)) res.setHeader(k, v);
+  res.status(200).send(body);
+});
 ```
 
 ### Static host (copy once)
@@ -187,8 +197,8 @@ await Nodepod.boot({
 ```
 
 With `serviceWorker: false` you keep the rest of Nodepod (filesystem,
-spawn, packages) but preview iframes and `nodepod.request()` to virtual
-ports won't work.
+spawn, packages, and programmatic `nodepod.request()` calls). Only navigable
+preview iframes and preview URLs are unavailable.
 
 ## Customising the URL
 
@@ -281,6 +291,6 @@ network behavior remain unchanged. Pass `rewriteTerminalUrls: false` to
 | `NodepodSWSetupError: HTTP 404` | No handler mounted | Add the plugin / route for your framework above |
 | `NodepodSWSetupError: wrong Content-Type (text/html)` | SPA fallback catching `/__sw__.js` | Ensure your router serves the SW *before* the fallback |
 | `NodepodSWSetupError: could not be reached` | CORS, network error, or timeout | Check devtools → Network; make sure the URL is same-origin |
-| SW registers but preview iframes are blank | Nodepod's `Cross-Origin-*` headers missing | Set `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: credentialless` on HTML responses |
+| SW registers but preview iframes are blank | Nodepod's `Cross-Origin-*` headers missing | Set `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: credentialless` (or the stricter `require-corp`) on HTML responses |
 | Hostname preview falls back and says the bridge document did not load | Bridge assets are missing, stale, or lack required headers on the preview hostname | Serve all three Nodepod assets on every preview hostname and restart stale dev servers after adding the routes |
 | A clean URL opened in a new tab shows the host site's root | The preview-host root is not routed to Nodepod's top-level bootstrap | Use the Vite integration or route preview-host `/` to `servePreviewBootstrap()`; keep the Nodepod host tab open and allow the one-time connection popup |


### PR DESCRIPTION
Audited the published docs against the current SDK and corrected API/setup mismatches.\n\n- wait for onServerReady before requesting an HTTP server\n- provide executable Express bridge handlers\n- clarify serviceWorker=false and CORS allowlist behavior\n- fix snapshot sync usage and ESM/CommonJS wording\n- align COEP guidance and live launch metadata\n\nVerified locally with pnpm run docs:check and the website Playwright suite.